### PR TITLE
DCOS-59088 [DS] [Spark Operator] Make Spark operator metrics available in Prometheus/Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ To submit Spark Application and check its status run:
 #switch to operator namespace, e.g.
 kubens spark-operator
 
+# Expose Spark Operator metrics service 
+kubectl create -f specs/spark-operator-service.yaml
+
+# Create ServiceMonitor (see prometheus-operator docs) for Spark 
+kubectl create -f specs/spark-service-monitor.yaml
+
 # create Spark application
 kubectl create -f specs/spark-application.yaml
 

--- a/specs/spark-application.yaml
+++ b/specs/spark-application.yaml
@@ -35,4 +35,18 @@ spec:
     exposeExecutorMetrics: true
     prometheus:
       jmxExporterJar: "/prometheus/jmx_prometheus_javaagent-0.11.0.jar"
-      port: 8090
+      port: 49151
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-task-runner-service-monitor
+  labels:
+    "spark/servicemonitor": "true"
+spec:
+  ports:
+    - port: 49151
+      name: metrics
+  clusterIP: None
+  selector:
+    "sparkoperator.k8s.io/app-name": mock-task-runner

--- a/specs/spark-operator-service.yaml
+++ b/specs/spark-operator-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: "v1"
+kind: Service
+metadata:
+  name: spark-operator-metrics
+  labels:
+    "spark/servicemonitor": "true"
+spec:
+  ports:
+    - port: 10254
+      name: metrics
+  clusterIP: None
+  selector:
+    "app.kubernetes.io/name": sparkoperator

--- a/specs/spark-service-monitor.yaml
+++ b/specs/spark-service-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: prometheus-operator
+    release: prometheus-kubeaddons
+  name: spark-cluster-monitor
+spec:
+  endpoints:
+    - interval: 5s
+      port: metrics
+  selector:
+    matchLabels:
+      spark/servicemonitor: "true"


### PR DESCRIPTION
___The changes came from https://github.com/mesosphere/data-services-tooling/pull/42___
___The description is copy-pasted from there___

The reason, why Spark's telemetry metrics were not appeared in Prometheus, is incompatibility between Google's spark-operator and prometheus-operator (coreos), which is shipped preinstalled within Konvoy. (Spark operator expects to have deals with kube-prometheus). More specifically, the prometheus-operator uses crafted services discovery approach, which is employ its own CRD - ServiceMonitor kind. So, the general rules to make metrics available for scrape by Prometheus (Prometheus-operator) are following:

ServiceMonitor should be created, having specified appropriate service endpoint selector AND matching namespace if interested pods are in non-default one.
Metrics port should be exposed by creating appropriate Service.
The service should be labeled by level, which will be matched by ServiceMonitor on them 1 (for example, kudo.dev/servicemonitor: "true").
How to verify these change?

Spin up Konvoy cluster and ensure cluster config is applied for kubectl.
Install Spark-operator and apply config, just by executing ./install.sh.
Deploy Spark driver within test app - run ./deploy_applications.sh.
Check pods, services statuses in Kubernetes dashboard, default namespace - spark-mwt
Wait 5-10 sec, and go to Prometheus dashboard. Type there spark and you will see a bunch of Spark's inartistic metrics.