### PR TITLE
[DCOS-59164] Ported Spark Operator Helm Chart to KUDO (PoC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 runs/
 state/
+.konvoy-*
+license.*
 
 admin.conf
 cluster.*.yaml

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ make cluster-destroy
 * Kubernetes cluster up and running
 * `kubectl` configured to work with provisioned cluster
 * `helm` client
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make cluster-destroy
 
 ### Installation
 
-To install Spark Operator from Helm Chart, run:
+To install KUDO Spark Operator, run:
 ```bash
 make install
 ```

--- a/kudo-operator/operator.yaml
+++ b/kudo-operator/operator.yaml
@@ -1,0 +1,29 @@
+name: "spark"
+version: "0.0.1"
+kudoVersion: 0.5.0
+kubernetesVersion: 1.15.0
+appVersion: "2.4.4"
+maintainers:
+  - Anton Kirillov <akirillov@d2iq.com>
+url: https://spark.apache.org/
+tasks:
+  deploy:
+    resources:
+      - spark-operator-rbac.yaml
+      - spark-operator-serviceaccount.yaml
+      - spark-rbac.yaml
+      - spark-serviceaccount.yaml
+      - webhook-init-job.yaml
+      - spark-operator-deployment.yaml
+      - webhook-service.yaml
+
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: deploy-spark
+        strategy: serial
+        steps:
+          - name: deploy
+            tasks:
+              - deploy

--- a/kudo-operator/params.yaml
+++ b/kudo-operator/params.yaml
@@ -1,0 +1,121 @@
+# Service Accounts and RBAC
+operatorServiceAccountName:
+  description: "Service Account for Spark Operator"
+  default: "spark-operator-service-account"
+  displayName: "Operator Service Account"
+
+createOperatorServiceAccount:
+  description: "Automatically create Service Account for Spark Operator"
+  default: true
+  displayName: "Auto Create Operator Service Account"
+
+sparkServiceAccountName:
+  description: "Use Service Account for Spark Drivers"
+  default: "spark-service-account"
+  displayName: "Spark Drivers Service Account"
+
+createSparkServiceAccount:
+  description: "Automatically generate Service Account for Spark Drivers"
+  default: true
+  displayName: "Auto Create Service Account for Spark Drivers"
+
+createRBAC:
+  description: "Automatically create RBAC for Spark Operator and Drivers"
+  default: true
+  displayName: "Auto Create RBAC for Spark Operator and Drivers"
+
+# Docker image
+operatorImageName:
+  description: "Operator Docker image name"
+  default: mesosphere/kudo-spark-operator
+  displayName: "Operator Docker image name"
+
+operatorVersion:
+  description: "Operator Docker image version (tag)"
+  default: latest
+  displayName: "Operator Docker image version (tag)"
+
+imagePullPolicy:
+  description: "Image pull policy"
+  default: Always
+  displayName: "Image pull policy"
+
+## Metrics
+enableMetrics:
+  description: "Enable Metrics"
+  default: false
+  displayName: "Enable Metrics"
+
+metricsPort:
+  description: "Metrics Port"
+  default: 10254
+  displayName: "Metrics Port"
+
+metricsEndpoint:
+  description: "Metrics Endpoint"
+  default: "/metrics"
+  displayName: "Metrics Endpoint"
+
+metricsPrefix:
+  description: "Metrics Prefix"
+  default: ""
+  displayName: "Metrics Prefix"
+
+resyncInterval:
+  description: "Resync interval"
+  default: 30
+  displayName: "Resync interval"
+
+## Miscellaneous
+sparkJobNamespace:
+  description: "Namespace for Spark Applications. Defaults to Operator namespace"
+  default: ""
+  displayName: "Namespace for Spark Applications"
+
+enableWebhook:
+  description: "Enable Webhook"
+  default: true
+  displayName: "Enable Webhook"
+
+webhookPort:
+  description: "Webhook port"
+  default: 8080
+  displayName: "Webhook port"
+
+controllerThreads:
+  description: "Controller threads"
+  default: 10
+  displayName: "Controller threads"
+
+ingressUrlFormat:
+  description: "Ingress URL format"
+  default: ""
+  displayName: "Ingress URL format"
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+## TODO: should be a map
+nodeSelector:
+  default: ""
+
+## Resources for the sparkoperator deployment
+## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+## TODO: should be a map
+resources:
+  default: ""
+
+## TODO: should be a map
+podAnnotations:
+  default: ""
+
+logLevel:
+  description: "Log Level"
+  default: 2
+  displayName: "Log Level"
+
+## Whether to enable batch scheduler for pod scheduling,
+## if enabled, end user can specify batch scheduler name in spark application.
+enableBatchScheduler:
+  description: "Enable Batch Scheduler"
+  default: false
+  displayName: "Enable Batch Scheduler"

--- a/kudo-operator/params.yaml
+++ b/kudo-operator/params.yaml
@@ -42,29 +42,29 @@ imagePullPolicy:
 
 ## Metrics
 enableMetrics:
-  description: "Enable Metrics"
+  description: "Enable metrics"
   default: false
-  displayName: "Enable Metrics"
+  displayName: "Enable metrics"
 
 metricsPort:
-  description: "Metrics Port"
+  description: "Metrics port"
   default: 10254
-  displayName: "Metrics Port"
+  displayName: "Metrics port"
 
 metricsEndpoint:
-  description: "Metrics Endpoint"
+  description: "Metrics endpoint"
   default: "/metrics"
-  displayName: "Metrics Endpoint"
+  displayName: "Metrics endpoint"
 
 metricsPrefix:
-  description: "Metrics Prefix"
+  description: "Metrics prefix"
   default: ""
-  displayName: "Metrics Prefix"
+  displayName: "Metrics prefix"
 
-resyncInterval:
-  description: "Resync interval"
+resyncIntervalSeconds:
+  description: "Informer resync interval in seconds"
   default: 30
-  displayName: "Resync interval"
+  displayName: "Informer resync interval in seconds"
 
 ## Miscellaneous
 sparkJobNamespace:
@@ -73,9 +73,9 @@ sparkJobNamespace:
   displayName: "Namespace for Spark Applications"
 
 enableWebhook:
-  description: "Enable Webhook"
+  description: "Enable webhook"
   default: true
-  displayName: "Enable Webhook"
+  displayName: "Enable webhook"
 
 webhookPort:
   description: "Webhook port"
@@ -108,6 +108,9 @@ resources:
 podAnnotations:
   default: ""
 
+
+## Output verbosity and debugging level
+## Ref: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
 logLevel:
   description: "Log Level"
   default: 2

--- a/kudo-operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/templates/spark-operator-deployment.yaml
@@ -26,11 +26,9 @@ spec:
     metadata:
     {{- if .Params.enableMetrics }}
       annotations:
-      {{- if .Params.enableMetrics }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Params.metricsPort }}"
         prometheus.io/path: {{ .Params.metricsEndpoint }}
-      {{- end }}
     {{- end }}
       labels:
         app.kubernetes.io/name: {{ .OperatorName }}
@@ -72,7 +70,7 @@ spec:
         {{- end }}
         - -ingress-url-format={{ .Params.ingressUrlFormat }}
         - -controller-threads={{ .Params.controllerThreads }}
-        - -resync-interval={{ .Params.resyncInterval }}
+        - -resync-interval={{ .Params.resyncIntervalSeconds }}
         - -logtostderr
         {{- if .Params.enableMetrics }}
         - -enable-metrics=true

--- a/kudo-operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/templates/spark-operator-deployment.yaml
@@ -1,0 +1,91 @@
+# If the admission webhook is enabled, then a post-install step is required
+# to generate and install the secret in the operator namespace.
+
+# In the post-install hook, the token corresponding to the operator service account
+# is used to authenticate with the Kubernetes API server to install the secret bundle.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .OperatorName }}
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+    app.kubernetes.io/version: {{ .Params.operatorVersion }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .OperatorName }}
+      app.kubernetes.io/instance: {{ .Name }}
+      app.kubernetes.io/version: {{ .Params.operatorVersion }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+    {{- if .Params.enableMetrics }}
+      annotations:
+      {{- if .Params.enableMetrics }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Params.metricsPort }}"
+        prometheus.io/path: {{ .Params.metricsEndpoint }}
+      {{- end }}
+    {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ .OperatorName }}
+        app.kubernetes.io/instance: {{ .Name }}
+        app.kubernetes.io/version: {{ .Params.operatorVersion }}
+      initializers:
+        pending: []
+    spec:
+      {{- if .Params.createOperatorServiceAccount }}
+      serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
+      {{- else }}
+      serviceAccountName: {{ .Params.operatorServiceAccountName }}
+      {{- end }}
+      {{- if .Params.enableWebhook }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: spark-webhook-certs
+      {{- end }}
+      containers:
+      - name: sparkoperator
+        image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
+        imagePullPolicy: {{ .Params.imagePullPolicy }}
+        {{- if .Params.enableWebhook }}
+        volumeMounts:
+          - name: webhook-certs
+            mountPath: /etc/webhook-certs
+        {{- end }}
+        {{- if .Params.enableMetrics }}
+        ports:
+          - containerPort: {{ .Params.metricsPort }}
+        {{ end }}
+        args:
+        - -v={{ .Params.logLevel }}
+        {{- if (ne .Params.sparkJobNamespace "") }}
+        - -namespace={{ .Params.sparkJobNamespace }}
+        {{- else }}
+        - -namespace={{ .Namespace }}
+        {{- end }}
+        - -ingress-url-format={{ .Params.ingressUrlFormat }}
+        - -controller-threads={{ .Params.controllerThreads }}
+        - -resync-interval={{ .Params.resyncInterval }}
+        - -logtostderr
+        {{- if .Params.enableMetrics }}
+        - -enable-metrics=true
+        - -metrics-labels=app_type
+        - -metrics-port={{ .Params.metricsPort }}
+        - -metrics-endpoint={{ .Params.metricsEndpoint }}
+        - -metrics-prefix={{ .Params.metricsPrefix }}
+        {{- end }}
+        - -enable-batch-scheduler={{ .Params.enableBatchScheduler }}
+        {{- if .Params.enableWebhook }}
+        - -enable-webhook=true
+        - -webhook-svc-namespace={{ .Namespace }}
+        - -webhook-port={{ .Params.webhookPort }}
+        - -webhook-svc-name={{ .OperatorName }}-webhook
+        - -webhook-config-name={{ .OperatorName }}-webhook-config
+        {{- end }}

--- a/kudo-operator/templates/spark-operator-rbac.yaml
+++ b/kudo-operator/templates/spark-operator-rbac.yaml
@@ -1,0 +1,61 @@
+{{- if .Params.createRBAC }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .OperatorName }}-cr
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["services", "configmaps", "secrets"]
+  verbs: ["create", "get", "delete", "update"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["create", "get", "delete"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "update", "patch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create", "get", "update", "delete"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations"]
+  verbs: ["create", "get", "update", "delete"]
+- apiGroups: ["sparkoperator.k8s.io"]
+  resources: ["sparkapplications", "scheduledsparkapplications"]
+  verbs: ["*"]
+  {{- if .Params.enableBatchScheduler }}
+  # This api resources below is configured for the `volcano` batch scheduler.
+- apiGroups: ["scheduling.incubator.k8s.io", "scheduling.sigs.dev"]
+  resources: ["podgroups"]
+  verbs: ["*"]
+  {{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .OperatorName }}-crb
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+subjects:
+  - kind: ServiceAccount
+    {{- if .Params.createOperatorServiceAccount }}
+    name: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
+    {{- else }}
+    name: {{ .Params.operatorServiceAccountName }}
+    {{- end }}
+    namespace: {{ .Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .OperatorName }}-cr
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/kudo-operator/templates/spark-operator-serviceaccount.yaml
+++ b/kudo-operator/templates/spark-operator-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Params.createOperatorServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Params.operatorServiceAccountName }}
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+{{- end }}

--- a/kudo-operator/templates/spark-rbac.yaml
+++ b/kudo-operator/templates/spark-rbac.yaml
@@ -12,18 +12,12 @@ metadata:
     app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
 rules:
-- apiGroups:
-  - "" # "" indicates the core API group
-  resources:
-  - "pods"
-  verbs:
-  - "*"
-- apiGroups:
-  - "" # "" indicates the core API group
-  resources:
-  - "services"
-  verbs:
-  - "*"
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kudo-operator/templates/spark-rbac.yaml
+++ b/kudo-operator/templates/spark-rbac.yaml
@@ -1,0 +1,56 @@
+{{- if .Params.createRBAC }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- if (ne .Params.sparkJobNamespace "") }}
+  namespace: {{ .Params.sparkJobNamespace }}
+  {{- else }}
+  namespace: {{ .Namespace }}
+  {{- end }}
+  name: spark-role
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+rules:
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - "pods"
+  verbs:
+  - "*"
+- apiGroups:
+  - "" # "" indicates the core API group
+  resources:
+  - "services"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+  {{- if (ne .Params.sparkJobNamespace "") }}
+  namespace: {{ .Params.sparkJobNamespace }}
+  {{- else }}
+  namespace: {{ .Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+subjects:
+- kind: ServiceAccount
+  {{- if .Params.createSparkServiceAccount }}
+  name: {{ .Name }}-{{ .Params.sparkServiceAccountName }}
+  {{- else }}
+  name: {{ .Params.sparkServiceAccountName }}
+  {{- end }}
+  {{- if (ne .Params.sparkJobNamespace "") }}
+  namespace: {{ .Params.sparkJobNamespace }}
+  {{- else }}
+  namespace: {{ .Namespace }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: spark-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/kudo-operator/templates/spark-serviceaccount.yaml
+++ b/kudo-operator/templates/spark-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Params.createSparkServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Params.sparkServiceAccountName }}
+  {{- if (ne .Params.sparkJobNamespace "") }}
+  namespace: {{ .Params.sparkJobNamespace }}
+  {{- else }}
+  namespace: {{ .Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+  {{- end }}

--- a/kudo-operator/templates/webhook-cleanup-job.yaml
+++ b/kudo-operator/templates/webhook-cleanup-job.yaml
@@ -1,0 +1,32 @@
+{{ if .Params.enableWebhook }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .OperatorName }}-webhook-cleanup
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+spec:
+  template:
+    spec:
+      {{- if .Params.createOperatorServiceAccount }}
+      serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
+      {{- else }}
+      serviceAccountName: {{ .Params.operatorServiceAccountName }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
+        imagePullPolicy: {{ .Params.imagePullPolicy }}
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "curl -ik \
+          -X DELETE \
+          -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
+          -H \"Accept: application/json\" \
+          -H \"Content-Type: application/json\" \
+          https://kubernetes.default.svc/api/v1/namespaces/{{ .Namespace }}/secrets/spark-webhook-certs"
+{{ end }}

--- a/kudo-operator/templates/webhook-init-job.yaml
+++ b/kudo-operator/templates/webhook-init-job.yaml
@@ -1,0 +1,24 @@
+{{ if .Params.enableWebhook }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .OperatorName }}-init
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+spec:
+  template:
+    spec:
+      {{- if .Params.createOperatorServiceAccount }}
+      serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
+      {{- else }}
+      serviceAccountName: {{ .Params.operatorServiceAccountName }}
+      {{- end }}
+      restartPolicy: OnFailure
+      containers:
+      - name: main
+        image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
+        imagePullPolicy: {{ .Params.imagePullPolicy }}
+        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Namespace }}", "-s", "{{ .OperatorName }}-webhook", "-p"]
+{{ end }}

--- a/kudo-operator/templates/webhook-service.yaml
+++ b/kudo-operator/templates/webhook-service.yaml
@@ -1,0 +1,19 @@
+{{ if .Params.enableWebhook }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .OperatorName }}-webhook
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+spec:
+  ports:
+  - port: 443
+    targetPort: {{ .Params.webhookPort }}
+    name: webhook
+  selector:
+    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/instance: {{ .Name }}
+    app.kubernetes.io/version: {{ .Params.operatorVersion }}
+{{ end }}

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -3,23 +3,22 @@
 set -ex
 SCRIPT_DIR=$(dirname "$0")
 SPECS_DIR="$(dirname ${SCRIPT_DIR})/specs"
+OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/kudo-operator"
 
-NAMESPACE=${NAMESPACE:-spark-operator}
-
-OPERATOR_NAME=${OPERATOR_NAME:-spark-operator}
+NAMESPACE=${NAMESPACE:-spark}
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}
 OPERATOR_VERSION=${OPERATOR_VERSION:-latest}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 
-helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+kubectl kudo init || true
 
-if [[ $(helm ls | grep "${OPERATOR_NAME}") ]]; then
-    echo "Spark Operator with name '${OPERATOR_NAME}' already installed"
-    echo "if you want to remove it run: helm delete --purge ${OPERATOR_NAME}"
+if [[ $(kubectl kudo get instances | grep spark) ]]; then
+    echo "Spark Operator with name already installed"
+    echo "if you want to remove it run: remove_operator.py"
 else
-    helm install incubator/sparkoperator --namespace "${NAMESPACE}" --name "${OPERATOR_NAME}" \
-    --set enableWebhook=true,sparkJobNamespace="${NAMESPACE}",enableMetrics=true,operatorImageName="${OPERATOR_IMAGE_NAME}",operatorVersion="${OPERATOR_VERSION}"
+    kubectl apply -f ${SPECS_DIR}/spark-namespace.yaml
+    kubectl kudo --namespace "${NAMESPACE}" install ${OPERATOR_DIR} -p operatorImageName="${OPERATOR_IMAGE_NAME}" -p operatorVersion="${OPERATOR_VERSION}"
 fi
 
 kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-driver-rbac.yaml

--- a/scripts/remove_operator.py
+++ b/scripts/remove_operator.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import subprocess
+import json
+import logging
+import os
+
+
+log = logging.getLogger(__name__)
+NAMESPACE = os.getenv("NAMESPACE", "spark")
+cmd = "kubectl --namespace {} get instances.kudo.dev -o json".format(NAMESPACE)
+
+def delete_resource(api, resource):
+    log.info("Deleting {} {}".format(api, resource))
+    subprocess.call("kubectl delete {} {}".format(api, resource), shell=True)
+
+subprocess.getoutput(cmd)
+instances = json.loads(subprocess.getoutput(cmd))
+
+versions = set()
+for instance in instances["items"]:
+    if instance["metadata"]["labels"]["kudo.dev/operator"] == "spark":
+        name = instance["metadata"]["name"]
+        plan = instance["status"]["activePlan"]["name"]
+
+        versions.add(instance["spec"]["operatorVersion"]["name"])
+        delete_resource("planexecutions.kudo.dev", plan)
+        delete_resource("instance.kudo.dev", name)
+
+for version in versions:
+    delete_resource("operatorversion.kudo.dev", version)
+
+delete_resource("operator.kudo.dev", "spark")

--- a/scripts/remove_operator.py
+++ b/scripts/remove_operator.py
@@ -5,8 +5,9 @@ import json
 import logging
 import os
 
-
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
+
 NAMESPACE = os.getenv("NAMESPACE", "spark")
 cmd = "kubectl --namespace {} get instances.kudo.dev -o json".format(NAMESPACE)
 

--- a/specs/spark-application.yaml
+++ b/specs/spark-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: "sparkoperator.k8s.io/v1beta2"
+apiVersion: "sparkoperator.k8s.io/v1beta1"
 kind: SparkApplication
 metadata:
   name: mock-task-runner
@@ -10,7 +10,7 @@ spec:
   mainClass: MockTaskRunner
   mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
   arguments:
-    - "5"
+    - "1"
     - "120"
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
@@ -26,7 +26,7 @@ spec:
     serviceAccount: spark-driver
   executor:
     cores: 1
-    instances: 5
+    instances: 1
     memory: "512m"
     labels:
       version: 2.4.4

--- a/specs/spark-namespace.yaml
+++ b/specs/spark-namespace.yaml
@@ -1,10 +1,6 @@
-{
-  "apiVersion": "v1",
-  "kind": "Namespace",
-  "metadata": {
-    "name": "spark",
-    "labels": {
-      "name": "spark"
-    }
-  }
-}
+"apiVersion": "v1",
+"kind": "Namespace",
+"metadata":
+  "name": "spark",
+  "labels":
+    "name": "spark"

--- a/specs/spark-namespace.yaml
+++ b/specs/spark-namespace.yaml
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "v1",
+  "kind": "Namespace",
+  "metadata": {
+    "name": "spark",
+    "labels": {
+      "name": "spark"
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resolves [DCOS-59164: Port Spark Operator Helm Chart to KUDO](https://jira.mesosphere.com/browse/DCOS-59164).

* added KUDO configuration and templates for Spark Operator based on [Spark Operator Helm Chart](https://github.com/helm/charts/tree/master/incubator/sparkoperator).
* updated installation script
* added `spark` namespace spec
* added cleanup script to teardown installed KUDO operator
* Operator uses the latest Docker image built from this repo using `make docker-build`
  * this image doesn't support `apiVersion: v1beta2` so the upgrade will be addressed in a separate PR

Notes:
* `kudo-operator` directory is temporary and will be moved to [kudobuilder/operators](https://github.com/kudobuilder/operators) once stabilized
* make sure you're using KUDO CLI 0.6.0
  ```
  $> kubectl kudo version
  KUDO Version: version.Info{GitVersion:"0.6.0", GitCommit:"c74d2274", BuildDate:"2019-09- 
  09T15:56:45Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"darwin/amd64"}
  ```

## How were these changes tested?

- by running the following commands on a cluster created with `make cluster-create`:
```
kubectl kudo init
kubectl apply -f specs/spark-namespace.yaml
kubectl kudo --namespace  spark install ./kudo-operator
kubectl kudo get instances --namespace spark
kubens
kubens spark
kubectl kudo get instances --namespace spark
kubectl kudo plan status --instance <instance name from the previous command output> --namespace spark

kubectl get pods

kubectl describe pod <operator pod name from the previous command output>
kubectl logs <operator pod name from the previous command output>

kubectl create -f specs/spark-driver-rbac.yaml
kubectl create -f specs/spark-application.yaml

kubectl get sparkapplications
kubectl describe sparkapplication mock-task-runner

kubectl get pods
kubectl logs mock-task-runner-driver
```