### PR TITLE
DCOS-59489 [DS] [Spark Operator] Update KUDO Spark Operator to support latest apiVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ KUBECONFIG ?= $(ROOT_DIR)/admin.conf
 
 DOCKER_REPO_NAME ?= mesosphere
 
-SPARK_IMAGE_NAME ?= spark-k8s
+SPARK_IMAGE_NAME ?= spark-2.4.4-bin-hadoop2.7-k8s
 SPARK_IMAGE_DOCKERFILE_PATH ?= $(ROOT_DIR)/images/spark
-SPARK_IMAGE_TAG ?= 2.4.4-hadoop2.7
+SPARK_IMAGE_TAG ?= $(call get_sha1sum,$(SPARK_IMAGE_DOCKERFILE_PATH)/Dockerfile)
 SPARK_IMAGE_FULL_NAME ?= $(DOCKER_REPO_NAME)/$(SPARK_IMAGE_NAME):$(SPARK_IMAGE_TAG)
 
 OPERATOR_IMAGE_NAME ?= kudo-spark-operator
 OPERATOR_DOCKERFILE_PATH ?= $(ROOT_DIR)/images/operator
-OPERATOR_VERSION ?= $(shell cat VERSION)
+OPERATOR_VERSION ?= $(call get_sha1sum,$(OPERATOR_DOCKERFILE_PATH)/Dockerfile)
 OPERATOR_IMAGE_FULL_NAME ?= $(DOCKER_REPO_NAME)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_VERSION)
 
 DOCKER_BUILDER_IMAGE_NAME ?= spark-operator-docker-builder
@@ -108,7 +108,3 @@ clean-all:
 clean-docker:
 	rm -f *-build docker-builder
 
-.PHONY: version
-version:
-	echo spark-k8s version - "${SPARK_IMAGE_TAG}"
-	echo kudo-spark-operator version - "${OPERATOR_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ docker-push:
 
 .PHONY: install
 install:
-	$(SCRIPTS_DIR)/install_operator.sh
+	OPERATOR_IMAGE_NAME=$(DOCKER_REPO_NAME)/$(OPERATOR_IMAGE_NAME) OPERATOR_VERSION=$(OPERATOR_VERSION) $(SCRIPTS_DIR)/install_operator.sh
 
 docker-builder:
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ KUBECONFIG ?= $(ROOT_DIR)/admin.conf
 
 DOCKER_REPO_NAME ?= mesosphere
 
-SPARK_IMAGE_NAME ?= spark-2.4.4-bin-hadoop2.7-k8s
+SPARK_IMAGE_NAME ?= spark-k8s
 SPARK_IMAGE_DOCKERFILE_PATH ?= $(ROOT_DIR)/images/spark
-SPARK_IMAGE_TAG ?= $(call get_sha1sum,$(SPARK_IMAGE_DOCKERFILE_PATH)/Dockerfile)
+SPARK_IMAGE_TAG ?= 2.4.4-hadoop2.7
 SPARK_IMAGE_FULL_NAME ?= $(DOCKER_REPO_NAME)/$(SPARK_IMAGE_NAME):$(SPARK_IMAGE_TAG)
 
 OPERATOR_IMAGE_NAME ?= kudo-spark-operator
 OPERATOR_DOCKERFILE_PATH ?= $(ROOT_DIR)/images/operator
-OPERATOR_VERSION ?= $(call get_sha1sum,$(OPERATOR_DOCKERFILE_PATH)/Dockerfile)
+OPERATOR_VERSION ?= $(shell cat VERSION)
 OPERATOR_IMAGE_FULL_NAME ?= $(DOCKER_REPO_NAME)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_VERSION)
 
 DOCKER_BUILDER_IMAGE_NAME ?= spark-operator-docker-builder
@@ -69,6 +69,7 @@ operator-build: spark-build
 
 .PHONY: docker-push
 docker-push:
+	docker push $(SPARK_IMAGE_FULL_NAME)
 	docker push $(OPERATOR_IMAGE_FULL_NAME)
 
 .PHONY: install
@@ -107,3 +108,7 @@ clean-all:
 clean-docker:
 	rm -f *-build docker-builder
 
+.PHONY: version
+version:
+	echo spark-k8s version - "${SPARK_IMAGE_TAG}"
+	echo kudo-spark-operator version - "${OPERATOR_VERSION}"

--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ To submit Spark Application and check its status run:
 #switch to operator namespace, e.g.
 kubens spark-operator
 
-# Expose Spark Operator metrics service 
-kubectl create -f specs/spark-operator-service.yaml
-
-# Create ServiceMonitor (see prometheus-operator docs) for Spark 
-kubectl create -f specs/spark-service-monitor.yaml
-
 # create Spark application
 kubectl create -f specs/spark-application.yaml
 

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,0 @@
-v0.0.1-SNAPSHOT

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+v0.0.1-SNAPSHOT

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -6,8 +6,16 @@ SPECS_DIR="$(dirname ${SCRIPT_DIR})/specs"
 OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/kudo-operator"
 
 NAMESPACE=${NAMESPACE:-spark}
+NAMESPACE=${NAMESPACE:-spark-operator}
+
+if [ -f "${SCRIPT_DIR}"/../operator-build ]; then
+  echo "operator-build file is found. Parse OPERATOR_IMAGE_NAME and OPERATOR_VERSION from there."
+  OPERATOR_IMAGE_NAME=$(awk -F':' '{printf $1}' <"${SCRIPT_DIR}"/../operator-build)
+  OPERATOR_VERSION=$(awk -F':' '{printf $2}' <"${SCRIPT_DIR}"/../operator-build)
+fi
+
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}
-OPERATOR_VERSION=${OPERATOR_VERSION:-$(<"${SCRIPT_DIR}"/../VERSION)}
+OPERATOR_VERSION=${OPERATOR_VERSION:-latest}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -7,7 +7,7 @@ OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/kudo-operator"
 
 NAMESPACE=${NAMESPACE:-spark}
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}
-OPERATOR_VERSION=${OPERATOR_VERSION:-latest}
+OPERATOR_VERSION=${OPERATOR_VERSION:-$(<"${SCRIPT_DIR}"/VERSION)}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -6,20 +6,6 @@ SPECS_DIR="$(dirname ${SCRIPT_DIR})/specs"
 OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/kudo-operator"
 
 NAMESPACE=${NAMESPACE:-spark}
-NAMESPACE=${NAMESPACE:-spark-operator}
-
-if [ -f "${SCRIPT_DIR}"/../operator-build ]; then
-  echo "operator-build file is found."
-  if [ -z "${OPERATOR_IMAGE_NAME}" ]; then
-    echo "Parse OPERATOR_IMAGE_NAME from operator-build file."
-    OPERATOR_IMAGE_NAME=$(awk -F':' '{printf $1}' <"${SCRIPT_DIR}"/../operator-build)
-  fi
-  if [ -z "${OPERATOR_VERSION}" ]; then
-     echo "Parse OPERATOR_VERSION from operator-build file."
-     OPERATOR_VERSION=$(awk -F':' '{printf $2}' <"${SCRIPT_DIR}"/../operator-build)
-  fi
-fi
-
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}
 OPERATOR_VERSION=${OPERATOR_VERSION:-latest}
 
@@ -31,8 +17,15 @@ if [[ $(kubectl kudo get instances | grep spark) ]]; then
     echo "Spark Operator with name already installed"
     echo "if you want to remove it run: remove_operator.py"
 else
-    kubectl apply -f ${SPECS_DIR}/spark-namespace.yaml
-    kubectl kudo --namespace "${NAMESPACE}" install ${OPERATOR_DIR} -p operatorImageName="${OPERATOR_IMAGE_NAME}" -p operatorVersion="${OPERATOR_VERSION}"
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: "${NAMESPACE}"
+      labels:
+        name: "${NAMESPACE}"
+EOF
+    kubectl kudo --namespace "${NAMESPACE}" install "${OPERATOR_DIR}" -p operatorImageName="${OPERATOR_IMAGE_NAME}" -p operatorVersion="${OPERATOR_VERSION}"
 fi
 
 kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-driver-rbac.yaml

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -9,9 +9,15 @@ NAMESPACE=${NAMESPACE:-spark}
 NAMESPACE=${NAMESPACE:-spark-operator}
 
 if [ -f "${SCRIPT_DIR}"/../operator-build ]; then
-  echo "operator-build file is found. Parse OPERATOR_IMAGE_NAME and OPERATOR_VERSION from there."
-  OPERATOR_IMAGE_NAME=$(awk -F':' '{printf $1}' <"${SCRIPT_DIR}"/../operator-build)
-  OPERATOR_VERSION=$(awk -F':' '{printf $2}' <"${SCRIPT_DIR}"/../operator-build)
+  echo "operator-build file is found."
+  if [ -z "${OPERATOR_IMAGE_NAME}" ]; then
+    echo "Parse OPERATOR_IMAGE_NAME from operator-build file."
+    OPERATOR_IMAGE_NAME=$(awk -F':' '{printf $1}' <"${SCRIPT_DIR}"/../operator-build)
+  fi
+  if [ -z "${OPERATOR_VERSION}" ]; then
+     echo "Parse OPERATOR_VERSION from operator-build file."
+     OPERATOR_VERSION=$(awk -F':' '{printf $2}' <"${SCRIPT_DIR}"/../operator-build)
+  fi
 fi
 
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -7,7 +7,7 @@ OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/kudo-operator"
 
 NAMESPACE=${NAMESPACE:-spark}
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME:-mesosphere/kudo-spark-operator}
-OPERATOR_VERSION=${OPERATOR_VERSION:-$(<"${SCRIPT_DIR}"/VERSION)}
+OPERATOR_VERSION=${OPERATOR_VERSION:-$(<"${SCRIPT_DIR}"/../VERSION)}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 
@@ -22,3 +22,7 @@ else
 fi
 
 kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-driver-rbac.yaml
+# Expose Spark Operator metrics service
+kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-operator-service.yaml
+# Create ServiceMonitor (see prometheus-operator docs) for Spark
+kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-service-monitor.yaml

--- a/specs/spark-namespace.yaml
+++ b/specs/spark-namespace.yaml
@@ -1,6 +1,6 @@
-"apiVersion": "v1",
-"kind": "Namespace",
-"metadata":
-  "name": "spark",
-  "labels":
-    "name": "spark"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "spark"
+  labels:
+    name: "spark"


### PR DESCRIPTION
**What is addressed in this PR?**
* synced mesosphere/spark-on-k8s-operator with the upstream
* updated spark-on-k8s-operator submodule in mesosphere/kudo-spark-operator to point to v1beta2-1.0.0-2.4.4 tag
* updated tooling to be able to build a working operator image which supports v1beta2 API version

Images build logs - [make_operator-build.log](https://github.com/mesosphere/kudo-spark-operator/files/3678844/make_operator-build.log)

kudo-spark-operator installation logs - [install_operator.log](https://github.com/mesosphere/kudo-spark-operator/files/3681171/install_operator.log)

The operator/controller logs - [logs-from-sparkoperator-in-spark-operator-sparkoperator-6bc599f75c-5xjff.txt](https://github.com/mesosphere/kudo-spark-operator/files/3681186/logs-from-sparkoperator-in-spark-operator-sparkoperator-6bc599f75c-5xjff.txt)

<img width="1651" alt="image" src="https://user-images.githubusercontent.com/7896911/66045908-4aa30f00-e52d-11e9-9785-dacadbc5f233.png">


**How to verify?**

**_Prerequisite_**
* Konvoy cluster is running and up. 
* `kubectl` configured to talk to the Konvoy cluster
* Docker installed on your host.

Steps:
1) Build operator (using customized docker repository name) - 
 ```bash
make operator-build DOCKER_REPO_NAME=<your_own_public_repo_on_docker_hub>
```
2) Login to Docker Hub:
```bash
docker login
``` 
3) Push these just built images to Docker Hub -
```bash
make docker-push DOCKER_REPO_NAME=<your_own_public_repo_on_docker_hub>
```
4) Install the operator onto Konvoy cluster -
```bash
make install
```
5) Install a Spark application example 
```bash 
kubectl create -n spark-operator -f spec/spark-application.yaml
```
6) 
* Go to Konvoy/Kubernetes dashboard. 
* Pick `spark-operator` namespace.
* And verify pods states on `Pods` tab, check their logs. 

There is all should be green.

Cheers!