### PR TITLE
Update setup for the Prometheus JMX exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPARK_OPERATOR_DIR := $(ROOT_DIR)/spark-on-k8s-operator
 KONVOY_VERSION ?= v1.1.5
 export KONVOY_VERSION
 
-NAMESPACE ?= spark-operator
+NAMESPACE ?= spark
 
 CLUSTER_TYPE ?= konvoy
 KUBECONFIG ?= $(ROOT_DIR)/admin.conf

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -34,9 +34,12 @@ WORKDIR ${SPARK_HOME}
 RUN rm jars/kubernetes-client-4.1.2.jar
 ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar jars
 
-RUN mkdir -p /prometheus \
-    && wget -O /prometheus/jmx_prometheus_javaagent-0.11.0.jar http://central.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar \
-    && chmod 777 /prometheus/jmx_prometheus_javaagent-0.11.0.jar
+# Setup for the Prometheus JMX exporter.
+RUN mkdir -p /etc/metrics/conf
+# Add the Prometheus JMX exporter Java agent jar for exposing metrics sent to the JmxSink to Prometheus.
+ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar /prometheus/
+COPY conf/metrics.properties /etc/metrics/conf
+COPY conf/prometheus.yaml /etc/metrics/conf
 
 WORKDIR ${SPARK_HOME}/work-dir
 

--- a/images/spark/conf/metrics.properties
+++ b/images/spark/conf/metrics.properties
@@ -1,0 +1,3 @@
+*.sink.jmx.class=org.apache.spark.metrics.sink.JmxSink
+driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/images/spark/conf/prometheus.yaml
+++ b/images/spark/conf/prometheus.yaml
@@ -1,0 +1,107 @@
+---
+lowercaseOutputName: true
+attrNameSnakeCase: true
+rules:
+  # These come from the application driver if it's a streaming application
+  # Example: default/streaming.driver.com.example.ClassName.StreamingMetrics.streaming.lastCompletedBatch_schedulingDelay
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(\S+)\.StreamingMetrics\.streaming\.(\S+)><>Value
+    name: spark_streaming_driver_$4
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # These come from the application driver if it's a structured streaming application
+  # Example: default/sstreaming.driver.spark.streaming.QueryName.inputRate-total
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.spark\.streaming\.(\S+)\.(\S+)><>Value
+    name: spark_structured_streaming_driver_$4
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      query_name: "$3"
+  # These come from the application executors
+  # Example: default/spark-pi.0.executor.threadpool.activeTasks
+  - pattern: metrics<name=(\S+)\.(\S+)\.(\S+)\.executor\.(\S+)><>Value
+    name: spark_executor_$4
+    type: GAUGE
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      executor_id: "$3"
+  # These come from the application driver
+  # Example: default/spark-pi.driver.DAGScheduler.stage.failedStages
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+    name: spark_driver_$3_$4
+    type: GAUGE
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # These come from the application driver
+  # Emulate timers for DAGScheduler like messagePRocessingTime
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.DAGScheduler\.(.*)><>Count
+    name: spark_driver_DAGScheduler_$3_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # HiveExternalCatalog is of type counter
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.HiveExternalCatalog\.(.*)><>Count
+    name: spark_driver_HiveExternalCatalog_$3_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.CodeGenerator\.(.*)><>Count
+    name: spark_driver_CodeGenerator_$3_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # These come from the application driver
+  # Emulate timer (keep only count attribute) plus counters for LiveListenerBus
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Count
+    name: spark_driver_LiveListenerBus_$3_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # Get Gauge type metrics for LiveListenerBus
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.LiveListenerBus\.(.*)><>Value
+    name: spark_driver_LiveListenerBus_$3
+    type: GAUGE
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+  # Executors counters
+  - pattern: metrics<name=(\S+)\.(\S+)\.(.*)\.executor\.(.*)><>Count
+    name: spark_executor_$4_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      executor_id: "$3"
+  # These come from the application executors
+  # Example: app-20160809000059-0000.0.jvm.threadpool.activeTasks
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.(jvm|NettyBlockTransfer)\.(.*)><>Value
+    name: spark_executor_$4_$5
+    type: GAUGE
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      executor_id: "$3"
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.HiveExternalCatalog\.(.*)><>Count
+    name: spark_executor_HiveExternalCatalog_$4_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      executor_id: "$3"
+  # These come from the application driver
+  # Emulate histograms for CodeGenerator
+  - pattern: metrics<name=(\S+)\.(\S+)\.([0-9]+)\.CodeGenerator\.(.*)><>Count
+    name: spark_executor_CodeGenerator_$4_count
+    type: COUNTER
+    labels:
+      app_namespace: "$1"
+      app_id: "$2"
+      executor_id: "$3"

--- a/specs/spark-namespace.yaml
+++ b/specs/spark-namespace.yaml
@@ -1,6 +1,6 @@
-"apiVersion": "v1",
-"kind": "Namespace",
-"metadata":
-  "name": "spark",
-  "labels":
-    "name": "spark"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "spark"
+  labels:
+    name: "spark"


### PR DESCRIPTION
This PR updates the steps required to setup Prometheus JMX exporter to adhere to the upstream

#### How the changes were tested?
Using scripts from this repo.
```
make spark-build DOCKER_REPO_NAME=<personal_docker_hub>
make docker-push
make cluster-create
make install
kubens spark  
kubectl create -f specs/spark-operator-service.yaml
kubectl create -f specs/spark-service-monitor.yaml
# spec.image was replaced with the one built earlier
kubectl create -f specs/spark-application.yaml 
```

Then go to Prometeus from Konvoy cluster dashboard and verify the metrics:
![image](https://user-images.githubusercontent.com/47157503/66132065-29115880-e5fd-11e9-9709-487e645c20fc.png)


