### PR TITLE
Added Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,10 @@
+### What changes were proposed in this pull request?
+Resolves [ticket ID](url) or # (issue)
+(Please include a summary of the change and which issue is fixed)
+
+### Why are the changes needed?
+(Please clarify why the changes are needed. For instance, please also include relevant motivation and context)
+
+### How were the changes tested?
+(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
+(If tests are complex, please provide steps to test locally)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the template for standardization of PRs. It was adopted from [mesosphere/spark-build](https://github.com/mesosphere/spark-build/blob/master/.github/PULL_REQUEST_TEMPLATE)

### Why are the changes needed?
Most of the time we request clarifications from contributors related but not limited to the ones outlined in the template. The template will save reviewers a few cycles by providing those questions and structure upfront.