### PR TITLE
Added number of nodes and instance type configuration support for Konvoy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ license.txt
 
 docker-*
 *.checksum
+*.bak
+*.tmp


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds default configuration parameters for Konvoy cluster size and instance types and provides support for changes implemented in https://github.com/mesosphere/data-services-kudo/pull/34

### Why are the changes needed?
To support cluster size modifications needed for integration testing (e.g. default cluster size is . not sufficient for testing shuffle jobs)

### How were the changes tested?
By running `make install WORKER_NODE_INSTANCE_TYPE=m4.xlarge WORKER_NODE_COUNT=6` and verifying that cluster.yaml was updated and created cluster has specified type and number of worker nodes.