### PR TITLE
[DCOS-59596] Enable Docker image publishing in CI builds

### DIFF
--- a/images/build.sh
+++ b/images/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR=$(dirname "$0")
-ROOT_DIR="$(dirname ${SCRIPT_DIR})/specs"
+ROOT_DIR="$(dirname ${SCRIPT_DIR})"
 
 pushd "${ROOT_DIR}"
 

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -38,7 +38,6 @@ ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes
 RUN mkdir -p /etc/metrics/conf
 # Add the Prometheus JMX exporter Java agent jar for exposing metrics sent to the JmxSink to Prometheus.
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar /prometheus/
-# test change
 COPY conf/metrics.properties /etc/metrics/conf
 COPY conf/prometheus.yaml /etc/metrics/conf
 

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -38,6 +38,7 @@ ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes
 RUN mkdir -p /etc/metrics/conf
 # Add the Prometheus JMX exporter Java agent jar for exposing metrics sent to the JmxSink to Prometheus.
 ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar /prometheus/
+# test change
 COPY conf/metrics.properties /etc/metrics/conf
 COPY conf/prometheus.yaml /etc/metrics/conf
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-59596 [DS] [Spark Operator] Enable Docker image publishing in CI builds](https://jira.mesosphere.com/browse/DCOS-59596)

Changes:
- fix `build.sh` to respect KUDO CI contract
- verification of CI changes implemented by @alembiewski 

### Why are the changes needed?
These changes were needed to verify that Docker images are built by CI when changed and fix the issue in `build.sh`.

### How were the changes tested?
- By adding artificial change (reverted later) and verifying that Docker publishing step is working. TC build: [link](https://teamcity.mesosphere.io/viewLog.html?buildId=2349878&buildTypeId=Frameworks_DataServices_Kudo_Spark_Pr_SparkPrKonvoyKudoV073&tab=buildResultsDiv), build logs: [PR_Spark_PR_Konvoy_KUDO-v0.7.3_30.log.zip](https://github.com/mesosphere/kudo-spark-operator/files/3719720/PR_Spark_PR_Konvoy_KUDO-v0.7.3_30.log.zip)
