### PR TITLE
Migrated images to Mesosphere Spark distribution

### DIFF
--- a/MONITORING.md
+++ b/MONITORING.md
@@ -52,7 +52,7 @@ the metrics on other one and see further instructions in next step.
    EOF
    ```  
 1) Composing your Spark Application yaml:
-   - use the following Spark image which includes the `JMXPrometheus` exporter jar: `mesosphere/spark:2.4.4-bin-hadoop2.7-k8s` 
+   - use the following Spark image which includes the `JMXPrometheus` exporter jar: `mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s`
    - enable Driver and Executors metrics reporting by adding the following configuration into `SparkApplication` `spec` section:
      ```yaml
        monitoring:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GNU Make is used as the main build tool and includes the following main targets:
 * `make cluster-create` creates a Konvoy or MKE cluster
 * `make cluster-destroy` creates a Konvoy or MKE cluster
 * `make clean-all` removes all artifacts produced by targets from local filesystem
-* `make docker-spark` builds Spark base image based on Apache Spark 2.4.4
+* `make docker-spark` builds Spark base image based on Apache Spark 2.4.3
 * `make docker-operator` builds Operator image and Spark base image if it's not built
 * `make docker-builder` builds image with required tools to run tests
 * `make docker-push` publishes Spark base image and Spark Operator image to DockerHub
@@ -45,8 +45,8 @@ To run tests on a pre-existing cluster with specified operator and spark images,
 
 ```
 make test KUBECONFIG=$HOME/.kube/config \
-SPARK_IMAGE_FULL_NAME=gcr.io/spark-operator/spark:v2.4.4-gcs-prometheus \
-OPERATOR_IMAGE_FULL_NAME=gcr.io/spark-operator/spark-operator
+SPARK_IMAGE_FULL_NAME=mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s \
+OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:spark-2.4.3-hadoop-2.9-k8s
 ```
 
 # Installing and using Spark Operator
@@ -55,7 +55,6 @@ OPERATOR_IMAGE_FULL_NAME=gcr.io/spark-operator/spark-operator
 
 * Kubernetes cluster up and running
 * `kubectl` configured to work with provisioned cluster
-* `helm` client
 * [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli)
 
 ### Installation

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -1,4 +1,4 @@
-ARG SPARK_IMAGE=mesosphere/spark-2.4.4-bin-hadoop2.7-k8s
+ARG SPARK_IMAGE=mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s
 
 FROM golang:1.12.5-alpine as builder
 LABEL stage=spark-operator-builder

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -3,8 +3,8 @@ FROM openjdk:8-alpine
 ARG SPARK_HOME=/opt/spark
 ARG SPARK_DIST=/dist
 ENV SPARK_HOME ${SPARK_HOME}
-ARG SPARK_DIST_NAME="spark-2.4.4-bin-hadoop2.7"
-ARG SPARK_DIST_URL="http://archive.apache.org/dist/spark/spark-2.4.4/${SPARK_DIST_NAME}.tgz"
+ARG SPARK_DIST_NAME="spark-2.4.3-hadoop-2.9-k8s"
+ARG SPARK_DIST_URL="https://downloads.mesosphere.io/spark/assets/${SPARK_DIST_NAME}.tgz"
 
 RUN set -ex && \
     apk upgrade --no-cache && \
@@ -33,10 +33,6 @@ WORKDIR ${SPARK_HOME}
 # https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/591
 RUN rm jars/kubernetes-client-4.1.2.jar
 ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar jars
-
-# Jars for S3 access support in case of Spark History Server
-ADD http://central.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar jars
-ADD http://central.maven.org/maven2/com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar jars
 
 # Setup for the Prometheus JMX exporter.
 RUN mkdir -p /etc/metrics/conf

--- a/kudo-operator/operator.yaml
+++ b/kudo-operator/operator.yaml
@@ -2,7 +2,7 @@ name: "spark"
 version: "0.0.1"
 kudoVersion: 0.7.3
 kubernetesVersion: 1.15.0
-appVersion: "2.4.4"
+appVersion: "2.4.3"
 maintainers:
   - name: Anton Kirillov
     email: akirillov@d2iq.com

--- a/specs/spark-application.yaml
+++ b/specs/spark-application.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: mesosphere/spark:2.4.4-bin-hadoop2.7-k8s
+  image: mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s
   imagePullPolicy: Always
   mainClass: MockTaskRunner
   mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
@@ -15,14 +15,14 @@ spec:
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
-  sparkVersion: "2.4.4"
+  sparkVersion: "2.4.3"
   restartPolicy:
     type: Never
   driver:
     cores: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.3
       metrics-exposed: "true"
     serviceAccount: spark-driver
   executor:
@@ -30,7 +30,7 @@ spec:
     instances: 1
     memory: "512m"
     labels:
-      version: 2.4.4
+      version: 2.4.3
       metrics-exposed: "true"
   monitoring:
     exposeDriverMetrics: true

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -12,9 +12,9 @@ const DefaultNamespace = "kudo-spark-operator-testing"
 const DefaultInstanceName = "test-instance"
 const rootDirName = "tests"
 
-var OperatorImage = getenvOr("OPERATOR_IMAGE", "mesosphere/kudo-spark-operator")
-var SparkImage = getenvOr("SPARK_IMAGE", "mesosphere/spark:2.4.4-bin-hadoop2.7-k8s")
-var SparkVersion = getenvOr("SPARK_VERSION", "2.4.4")
+var OperatorImage = getenvOr("OPERATOR_IMAGE", "mesosphere/kudo-spark-operator:spark-2.4.3-hadoop-2.9-k8s")
+var SparkImage = getenvOr("SPARK_IMAGE", "mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s")
+var SparkVersion = getenvOr("SPARK_VERSION", "2.4.3")
 var TestDir = getenvOr("TEST_DIR", goUpToRootDir())
 var KubeConfig = getenvOr("KUBECONFIG", filepath.Join(os.Getenv("HOME"), ".kube", "config"))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60155: Use mesosphere/spark distribution in Docker images](https://jira.mesosphere.com/browse/DCOS-60155).

This PR migrates Spark base and operator images to mesosphere/spark distribution built with Hadoop 2.9.2 and `hadoop-cloud` support.

The process of building Spark K8s distribution is described in [corporate wiki](https://wiki.mesosphere.com/display/ENG/Building+Spark+Operator+distribution+and+images).

### Why are the changes needed?
Apache Spark distribution tarball which is built with Hadoop 2.7 lacks `hadoop-cloud` profile dependencies and prevents us from using S3A locations for SHS and using newer credentials providers implementations for application which use session tokens for S3 access.

### How were the changes tested?
- integration tests from this repo
- scale tests from https://github.com/mesosphere/kudo-spark-operator/pull/26 used the same changes and passed successfully