### PR TITLE
[DCOS-60223] [DS] [Spark Operator] Boolean parameters are not being treated as Boolean by KUDO

### DIFF
--- a/kudo-operator/params.yaml
+++ b/kudo-operator/params.yaml
@@ -71,35 +71,10 @@ resyncIntervalSeconds:
   default: 30
   displayName: "Informer resync interval in seconds"
 
-## Miscellaneous
-sparkJobNamespace:
-  description: "Namespace for Spark Applications. Defaults to Operator namespace"
-  default: ""
-  displayName: "Namespace for Spark Applications"
-
-enableWebhook:
-  description: "Enable webhook"
-  default: true
-  displayName: "Enable webhook"
-
-webhookPort:
-  description: "Webhook port"
-  default: 8080
-  displayName: "Webhook port"
-
-controllerThreads:
-  description: "Controller threads"
-  default: 10
-  displayName: "Controller threads"
-
-ingressUrlFormat:
-  description: "Ingress URL format"
-  default: ""
-  displayName: "Ingress URL format"
-
+# History Server
 enableHistoryServer:
   description: "Start Spark History Server"
-  required: false
+  default: false
   displayName: "Enable Spark History Server"
 
 historyServerFsLogDirectory:
@@ -131,6 +106,32 @@ historyServerPVCName:
   description: "External Persistent Volume Claim Name used for Spark event logs storage by History Server"
   default: ""
   displayName: "Spark History Server Persistent Volume Claim Name"
+
+## Miscellaneous
+sparkJobNamespace:
+  description: "Namespace for Spark Applications. Defaults to Operator namespace"
+  default: ""
+  displayName: "Namespace for Spark Applications"
+
+enableWebhook:
+  description: "Enable webhook"
+  default: true
+  displayName: "Enable webhook"
+
+webhookPort:
+  description: "Webhook port"
+  default: 8080
+  displayName: "Webhook port"
+
+controllerThreads:
+  description: "Controller threads"
+  default: 10
+  displayName: "Controller threads"
+
+ingressUrlFormat:
+  description: "Ingress URL format"
+  default: ""
+  displayName: "Ingress URL format"
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/

--- a/kudo-operator/templates/spark-application-metrics-service.yaml
+++ b/kudo-operator/templates/spark-application-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.enableMetrics }}
+{{- if eq .Params.enableMetrics "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/kudo-operator/templates/spark-history-server-deployment.yaml
+++ b/kudo-operator/templates/spark-history-server-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.enableHistoryServer }}
+{{- if eq .Params.enableHistoryServer "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/version: {{ .Params.operatorVersion }}
     spec:
-      {{- if .Params.createOperatorServiceAccount }}
+      {{- if eq .Params.createOperatorServiceAccount "true" }}
       serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
       {{- else }}
       serviceAccountName: {{ .Params.operatorServiceAccountName }}

--- a/kudo-operator/templates/spark-history-server-service.yaml
+++ b/kudo-operator/templates/spark-history-server-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.enableHistoryServer }}
+{{- if eq .Params.enableHistoryServer "true" }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/kudo-operator/templates/spark-operator-crds.yaml
+++ b/kudo-operator/templates/spark-operator-crds.yaml
@@ -1,4 +1,4 @@
-{{ if .Params.installCrds }}
+{{- if eq .Params.installCrds "true" }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -5088,4 +5088,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-  {{ end }}
+  {{- end }}

--- a/kudo-operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/templates/spark-operator-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- else }}
       serviceAccountName: {{ .Params.operatorServiceAccountName }}
       {{- end }}
-      {{- if .Params.enableWebhook }}
+      {{- if eq .Params.enableWebhook "true" }}
       volumes:
         - name: webhook-certs
           secret:

--- a/kudo-operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/templates/spark-operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     type: Recreate
   template:
     metadata:
-    {{- if .Params.enableMetrics }}
+    {{- if eq .Params.enableMetrics "true" }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Params.operatorMetricsPort }}"
@@ -37,7 +37,7 @@ spec:
       initializers:
         pending: []
     spec:
-      {{- if .Params.createOperatorServiceAccount }}
+      {{- if eq .Params.createOperatorServiceAccount "true" }}
       serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
       {{- else }}
       serviceAccountName: {{ .Params.operatorServiceAccountName }}
@@ -52,12 +52,12 @@ spec:
       - name: sparkoperator
         image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
         imagePullPolicy: {{ .Params.imagePullPolicy }}
-        {{- if .Params.enableWebhook }}
+        {{- if eq .Params.enableWebhook "true" }}
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook-certs
         {{- end }}
-        {{- if .Params.enableMetrics }}
+        {{- if eq .Params.enableMetrics "true" }}
         ports:
           - containerPort: {{ .Params.operatorMetricsPort }}
         {{ end }}
@@ -72,7 +72,7 @@ spec:
         - -controller-threads={{ .Params.controllerThreads }}
         - -resync-interval={{ .Params.resyncIntervalSeconds }}
         - -logtostderr
-        {{- if .Params.enableMetrics }}
+        {{- if eq .Params.enableMetrics "true" }}
         - -enable-metrics=true
         - -metrics-labels=app_type
         - -metrics-port={{ .Params.operatorMetricsPort }}
@@ -80,7 +80,7 @@ spec:
         - -metrics-prefix={{ .Params.metricsPrefix }}
         {{- end }}
         - -enable-batch-scheduler={{ .Params.enableBatchScheduler }}
-        {{- if .Params.enableWebhook }}
+        {{- if eq .Params.enableWebhook "true" }}
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Namespace }}
         - -webhook-port={{ .Params.webhookPort }}

--- a/kudo-operator/templates/spark-operator-metrics-service.yaml
+++ b/kudo-operator/templates/spark-operator-metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.enableMetrics }}
+{{- if eq .Params.enableMetrics "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/kudo-operator/templates/spark-operator-rbac.yaml
+++ b/kudo-operator/templates/spark-operator-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.createRBAC }}
+{{- if eq .Params.createRBAC "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -31,7 +31,7 @@ rules:
 - apiGroups: ["sparkoperator.k8s.io"]
   resources: ["sparkapplications", "scheduledsparkapplications", "sparkapplications/status", "scheduledsparkapplications/status"]
   verbs: ["*"]
-  {{- if .Params.enableBatchScheduler }}
+  {{- if eq .Params.enableBatchScheduler "true" }}
   # This api resources below is configured for the `volcano` batch scheduler.
 - apiGroups: ["scheduling.incubator.k8s.io", "scheduling.sigs.dev"]
   resources: ["podgroups"]
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Name }}
 subjects:
   - kind: ServiceAccount
-    {{- if .Params.createOperatorServiceAccount }}
+    {{- if eq .Params.createOperatorServiceAccount "true" }}
     name: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
     {{- else }}
     name: {{ .Params.operatorServiceAccountName }}

--- a/kudo-operator/templates/spark-operator-serviceaccount.yaml
+++ b/kudo-operator/templates/spark-operator-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.createOperatorServiceAccount }}
+{{- if eq .Params.createOperatorServiceAccount "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kudo-operator/templates/spark-rbac.yaml
+++ b/kudo-operator/templates/spark-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.createRBAC }}
+{{- if eq .Params.createRBAC "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Name }}
 subjects:
 - kind: ServiceAccount
-  {{- if .Params.createSparkServiceAccount }}
+  {{- if eq .Params.createSparkServiceAccount "true" }}
   name: {{ .Name }}-{{ .Params.sparkServiceAccountName }}
   {{- else }}
   name: {{ .Params.sparkServiceAccountName }}

--- a/kudo-operator/templates/spark-serviceaccount.yaml
+++ b/kudo-operator/templates/spark-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Params.createSparkServiceAccount }}
+{{- if eq .Params.createSparkServiceAccount "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,4 +11,4 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
-  {{- end }}
+{{- end }}

--- a/kudo-operator/templates/webhook-cleanup-job.yaml
+++ b/kudo-operator/templates/webhook-cleanup-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Params.enableWebhook }}
+{{- if eq .Params.enableWebhook "true" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     spec:
-      {{- if .Params.createOperatorServiceAccount }}
+      {{- if eq .Params.createOperatorServiceAccount "true" }}
       serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
       {{- else }}
       serviceAccountName: {{ .Params.operatorServiceAccountName }}
@@ -29,4 +29,4 @@ spec:
           -H \"Accept: application/json\" \
           -H \"Content-Type: application/json\" \
           https://kubernetes.default.svc/api/v1/namespaces/{{ .Namespace }}/secrets/spark-webhook-certs"
-{{ end }}
+{{- end }}

--- a/kudo-operator/templates/webhook-init-job.yaml
+++ b/kudo-operator/templates/webhook-init-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Params.enableWebhook }}
+{{- if eq .Params.enableWebhook "true" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     spec:
-      {{- if .Params.createOperatorServiceAccount }}
+      {{- if eq .Params.createOperatorServiceAccount "true" }}
       serviceAccountName: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
       {{- else }}
       serviceAccountName: {{ .Params.operatorServiceAccountName }}
@@ -21,4 +21,4 @@ spec:
         image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
         imagePullPolicy: {{ .Params.imagePullPolicy }}
         command: ["/usr/bin/gencerts.sh", "-n", "{{ .Namespace }}", "-s", "{{ .OperatorName }}-webhook", "-p"]
-{{ end }}
+{{- end }}

--- a/kudo-operator/templates/webhook-service.yaml
+++ b/kudo-operator/templates/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Params.enableWebhook }}
+{{- if eq .Params.enableWebhook "true" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -16,4 +16,4 @@ spec:
     app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
-{{ end }}
+{{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60223: Boolean check fix](https://jira.mesosphere.com/browse/DCOS-60223)

It introduces the fix for Boolean parameter being treated as String by KUDO Templating. Modifies all the IF conditions involved Boolean values to have equality check with the String "true".

### Why are the changes needed?
In KUDO template, Boolean values are treated as String, so all the IF conditions were checking it correctly.

### How were the changes tested?
By manually running `make install`.