### PR TITLE
Verify that a namespace is truly deleted after an API call

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -20,12 +20,12 @@ func TestSparkOperatorInstallation(t *testing.T) {
 	defer spark.CleanUp()
 
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	k8sNamespace, err := spark.Clients.CoreV1().Namespaces().Get(spark.Namespace, v1.GetOptions{})
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	log.Infof("Spark operator is installed in namespace %s", k8sNamespace.Name)
@@ -40,12 +40,12 @@ func TestSparkOperatorInstallationWithCustomNamespace(t *testing.T) {
 	defer spark.CleanUp()
 
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	k8sNamespace, err := spark.Clients.CoreV1().Namespaces().Get(spark.Namespace, v1.GetOptions{})
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if k8sNamespace.Name != customNamespace {
@@ -59,7 +59,7 @@ func TestJobSubmission(t *testing.T) {
 	defer spark.CleanUp()
 
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	job := utils.SparkJob{
@@ -72,7 +72,7 @@ func TestJobSubmission(t *testing.T) {
 
 	err = spark.SubmitJob(job)
 	if err != nil {
-		t.Error(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	err = spark.WaitUntilSucceeded(job)

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +55,7 @@ func DropNamespace(clientSet *kubernetes.Clientset, name string) error {
 	return retry(namespaceDeletionTimeout, 3*time.Second, func() error {
 		_, err := clientSet.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 		if err == nil {
-			return errors.New("the namespace is still there")
+			return errors.New(fmt.Sprintf("namespace %s is still there", name))
 		} else if statusErr, ok := err.(*apiErrors.StatusError); !ok || statusErr.Status().Reason != metav1.StatusReasonNotFound {
 			return err
 		} else {

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -56,11 +56,11 @@ func DropNamespace(clientSet *kubernetes.Clientset, name string) error {
 	return retry(namespaceDeletionTimeout, namespaceDeletionCheckInterval, func() error {
 		_, err := clientSet.CoreV1().Namespaces().Get(name, metav1.GetOptions{})
 		if err == nil {
-			return errors.New(fmt.Sprintf("Namespace %s is still there", name))
+			return errors.New(fmt.Sprintf("Namespace '%s' still exists", name))
 		} else if statusErr, ok := err.(*apiErrors.StatusError); !ok || statusErr.Status().Reason != metav1.StatusReasonNotFound {
 			return err
 		} else {
-			log.Info(fmt.Sprintf("Namespace %s is deleted", name))
+			log.Info(fmt.Sprintf("Namespace '%s' successfully deleted", name))
 			return nil
 		}
 	})


### PR DESCRIPTION
### What changes were proposed in this pull request and why are they needed?
Resolves integration test issues when a namespace is not immediately deleted after an API call, resulting in errors like this in further tests:
```
Error from server (Forbidden): error when creating "/tmp/job-886088610": sparkapplications.sparkoperator.k8s.io "linear-regression" is forbidden: unable to create new content in namespace kudo-spark-operator-testing because it is being terminated 
```


### How were the changes tested?
With `make cluster-create` and `make test`
