### PR TITLE
[DCOS-59715] Added docs for versions, limitations, and release notes

### DIFF
--- a/kudo-operator/docs/latest/limitations.md
+++ b/kudo-operator/docs/latest/limitations.md
@@ -1,2 +1,10 @@
 Limitations
 ---
+
+## Multi-instance installation
+* Currently, multi-instance (multi-tenant) operator installation supports only a single instance per namespace to
+allow Spark applications be launched in the namespace they've been submitted to. Multiple operator instances
+installed in the same namespace run job submissions in parallel which can potentially lead to race conditions
+and inconsistent application state.
+* Operator instances must have unique names to avoid clashes when `createRBAC` property is set to `true`.
+KUDO Controller will reject new instance installation because it will try to create a `ClusterRole` with the same name.

--- a/kudo-operator/docs/latest/release-notes.md
+++ b/kudo-operator/docs/latest/release-notes.md
@@ -1,2 +1,10 @@
 Release Notes
 ---
+
+## latest
+* Spark Operator Docker image based on [mesosphere/spark](https://github.com/mesosphere/spark/) 2.4.3 with Hadoop 2.9.2 support
+* Google Spark Operator based on version `v1beta2-1.0.1`
+* Added Spark History Server support
+* Added `ServiceMonitors` for integration with the Prometheus Operator
+* Prometheus Java agent updated to version `0.11.0`
+* Kubernetes Java client library updated to version `4.4.2`

--- a/kudo-operator/docs/latest/versions.md
+++ b/kudo-operator/docs/latest/versions.md
@@ -1,2 +1,11 @@
 Versions
 ---
+
+## Component Versions
+* Apache Spark 2.4.3 built with Hadoop 2.9.2 and Scala 2.11
+* Google Spark Operator v1beta2-1.0.1
+* OpenJDK 8
+* Prometheus Java agent 0.11.0
+
+## KUDO Version Requirement
+* KUDO version 0.7.5 or later


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-59715: Add release notes, limitations, and versions sections to KUDO Spark docs](https://jira.mesosphere.com/browse/DCOS-59715).

This PR adds documentation for component versions, limitations, and release notes.
### Why are the changes needed?
The change is needed as a part of the operator documentation.

### How were the changes tested?
* tests from this repo
* by reviewing rendered markdown and verifying that links and the markup are correctly displayed