### PR TITLE
[DCOS-59711] Added installation documentation for KUDO Spark

### DIFF
--- a/kudo-operator/docs/latest/installation.md
+++ b/kudo-operator/docs/latest/installation.md
@@ -1,2 +1,61 @@
 KUDO Spark Operator Installation 
 ---
+
+## Installing the KUDO Spark Operator
+
+Requirements:
+
+- Install the [KUDO controller](https://kudo.dev/docs/getting-started/)
+- Install the [KUDO CLI](https://kudo.dev/docs/cli/)
+
+## Installing the Operator
+
+Check out existing [limitations](./limitations.md) before installing a KUDO Spark instance. Currently, multi-instance 
+(multi-tenant) operator installation supports only a single instance per namespace. 
+
+
+```
+kubectl kudo install spark --instance=spark
+```
+
+Verify the if the deploy plan for `--instance=spark` is complete.
+```
+kubectl kudo plan status --instance=spark
+Plan(s) for "spark" in namespace "default":
+.
+└── spark (Operator-Version: "spark-0.1.0" Active-Plan: "spark-deploy-177456474")
+    └── Plan deploy (serial strategy) [COMPLETE]
+        └── Phase deploy-spark (serial strategy) [COMPLETE]
+            └── Step deploy (COMPLETE)
+```
+
+You can view all configuration options [here](./configuration.md)
+
+#### Installing multiple Spark Operator Instances
+
+Optionally, create dedicated namespaces for installing KUDO Spark instances(e.g. `spark-operator-1` and `spark-operator-2` in this example):
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spark-operator-1
+  labels:
+    name: spark-operator-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spark-operator-2
+  labels:
+    name: spark-operator-2
+```
+
+
+```
+kubectl kudo install spark --instance=spark-1 --namespace spark-operator-1
+kubectl kudo install spark --instance=spark-2 --namespace spark-operator-2
+```
+
+The above commands will install two Spark Operators in two different namespaces. Spark Applications submitted to a specific
+namespace will be handled by the Operator installed in the same namespace.

--- a/kudo-operator/docs/latest/installation.md
+++ b/kudo-operator/docs/latest/installation.md
@@ -13,19 +13,19 @@ Requirements:
 Check out existing [limitations](./limitations.md) before installing a KUDO Spark instance. Currently, multi-instance 
 (multi-tenant) operator installation supports only a single instance per namespace. 
 
-
 ```
 kubectl kudo install spark --instance=spark
 ```
 
-Verify the if the deploy plan for `--instance=spark` is complete.
+Verify if the deploy plan for `--instance=spark` is complete:
 ```
 kubectl kudo plan status --instance=spark
+
 Plan(s) for "spark" in namespace "default":
 .
-└── spark (Operator-Version: "spark-0.1.0" Active-Plan: "spark-deploy-177456474")
+└── spark (Operator-Version: "spark-beta1" Active-Plan: "deploy")
     └── Plan deploy (serial strategy) [COMPLETE]
-        └── Phase deploy-spark (serial strategy) [COMPLETE]
+        └── Phase deploy-spark [COMPLETE]
             └── Step deploy (COMPLETE)
 ```
 
@@ -49,6 +49,7 @@ metadata:
   name: spark-operator-2
   labels:
     name: spark-operator-2
+EOF
 ```
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-59711: Document installation of KUDO Spark Operator](https://jira.mesosphere.com/browse/DCOS-59711)

This PR adds documentation for the basic installation steps for the beta release.

### Why are the changes needed?
The change is needed as a part of the operator documentation.

### How were the changes tested?
* tests from this repo
* by reviewing rendered markdown and verifying that links and the markup are correctly displayed