### PR TITLE
[DCOS-60483] [DS] [Spark Operator] Update the KUDO version from 0.7.3 to 0.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Required software:
 * GNU Make 4.2.1 or higher
 * sha1sum
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.3 or higher
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.5 or higher
 
 For test cluster provisioning and Stub Universe artifacts upload valid AWS access credentials required:
 * `AWS_PROFILE` **or** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables should be provided
@@ -55,7 +55,7 @@ OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:spark-2.4.3-hadoop-2.9-k
 
 * Kubernetes cluster up and running
 * `kubectl` configured to work with provisioned cluster
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli)
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.5 or higher
 
 ### Installation
 

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -3,6 +3,6 @@ FROM golang:1.13.0@sha256:de697ce5ae02f3d9a57b0603fbb648efadfa212727e702ad3a807b
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
-    curl -L https://github.com/kudobuilder/kudo/releases/download/v0.7.3/kubectl-kudo_0.7.3_linux_x86_64 -o /go/bin/kubectl-kudo && \
+    curl -L https://github.com/kudobuilder/kudo/releases/download/v0.7.5/kubectl-kudo_0.7.5_linux_x86_64 -o /go/bin/kubectl-kudo && \
     chmod +x /go/bin/kubectl-kudo && \
     go get github.com/2tvenom/go-test-teamcity


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60483: Update KUDO version](https://jira.mesosphere.com/browse/DCOS-60483)

Updates KUDO version to `0.7.5` mentioned in the project.

### Why are the changes needed?
There were some places where still KUDO version was `0.7.3`, which we are no longer supporting.

### How were the changes tested?
Ran `make install` and `make tests` locally
