### PR TITLE
Updated Operator image build paths to explicitly use source code from git module

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -7,11 +7,11 @@ RUN apk add --no-cache bash git
 ADD https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 /usr/bin/dep
 RUN chmod +x /usr/bin/dep
 
+COPY . ${GOPATH}/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
 WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
-COPY Gopkg.toml Gopkg.lock ./
-RUN dep ensure -vendor-only
-COPY . ./
-RUN go generate && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
+RUN dep ensure -vendor-only \
+    && go generate \
+    && CGO_ENABLED=0 GOOS=linux go build -o /usr/bin/spark-operator
 
 FROM ${SPARK_IMAGE}
 COPY --from=builder /usr/bin/spark-operator /usr/bin/


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR updates the Operator Dockerfile to explicitly use source code from git submodule and removes redundant `COPY`:
```
WORKDIR ${GOPATH}/src/github.com/GoogleCloudPlatform/spark-on-k8s-operator
COPY Gopkg.toml Gopkg.lock ./
``` 

### Why are the changes needed?
To simplify the troubleshooting of the image build process and remove redundant code.

### How were the changes tested?
- integration tests from this repo