### PR TITLE
DCOS-60350: Integration tests for service account creation

### DIFF
--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -1,0 +1,143 @@
+package tests
+
+import (
+	"github.com/mesosphere/kudo-spark-operator/tests/utils"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestDefaultServiceAccounts(t *testing.T) {
+	const driverSA = "spark-service-account"
+	const operatorSA = "spark-operator-service-account"
+	spark := utils.SparkOperatorInstallation{
+		Namespace: "test-default-service-accounts",
+		Params: map[string]string{
+			"createOperatorServiceAccount": "true",
+			"createSparkServiceAccount":    "true",
+			"operatorServiceAccountName":   operatorSA,
+			"sparkServiceAccountName":      driverSA,
+		},
+	}
+
+	err := testServiceAccounts(spark,
+		utils.DefaultInstanceName+"-"+operatorSA,
+		utils.DefaultInstanceName+"-"+driverSA)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestSparkServiceAccount(t *testing.T) {
+	const namespace = "test-provided-spark-sa"
+	const driverSA = "spark-driver"
+	const operatorSA = "spark-operator-service-account"
+
+	// Prepare a namespace with a service account
+	err := createNamespaceAndServiceAccount(namespace, driverSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spark := utils.SparkOperatorInstallation{
+		Namespace:            namespace,
+		SkipNamespaceCleanUp: true,
+		Params: map[string]string{
+			"createOperatorServiceAccount": "true",
+			"operatorServiceAccountName":   operatorSA,
+			"createSparkServiceAccount":    "false",
+			"sparkServiceAccountName":      driverSA,
+		},
+	}
+
+	err = testServiceAccounts(spark, utils.DefaultInstanceName+"-"+operatorSA, driverSA)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestOperatorServiceAccount(t *testing.T) {
+	const namespace = "test-provided-operator-sa"
+	const driverSA = "spark-service-account"
+	const operatorSA = "operator-test-service-account"
+
+	// Prepare a namespace with a service account
+	err := createNamespaceAndServiceAccount(namespace, operatorSA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spark := utils.SparkOperatorInstallation{
+		Namespace:            namespace,
+		SkipNamespaceCleanUp: true,
+		Params: map[string]string{
+			"createOperatorServiceAccount": "false",
+			"operatorServiceAccountName":   operatorSA,
+			"createSparkServiceAccount":    "true",
+			"sparkServiceAccountName":      driverSA,
+		},
+	}
+
+	err = testServiceAccounts(spark, operatorSA, utils.DefaultInstanceName+"-"+driverSA)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func createNamespaceAndServiceAccount(namespace string, saName string) error {
+	client, err := utils.GetK8sClientSet()
+	if err != nil {
+		return err
+	}
+	_, err = utils.CreateNamespace(client, namespace)
+	if err != nil {
+		return err
+	}
+
+	return utils.CreateServiceAccount(client, saName, namespace)
+}
+
+func testServiceAccounts(spark utils.SparkOperatorInstallation, operatorSAName string, driverSAName string) error {
+	err := spark.InstallSparkOperator()
+	defer spark.CleanUp()
+
+	if err != nil {
+		return err
+	}
+
+	// Verify that SAs exists
+	_, err = spark.K8sClients.CoreV1().ServiceAccounts(spark.Namespace).Get(operatorSAName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Can't get operator service account '%s'", operatorSAName)
+		return err
+	}
+
+	_, err = spark.K8sClients.CoreV1().ServiceAccounts(spark.Namespace).Get(driverSAName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Can't get Spark driver service account '%s'", driverSAName)
+		return err
+	}
+
+	// Run a test job
+	jobName := "mock-task-runner"
+	job := utils.SparkJob{
+		Name:           jobName,
+		Template:       "spark-mock-task-runner-job.yaml",
+		ServiceAccount: driverSAName,
+		Params: map[string]interface{}{
+			"args": []string{"1", "15"},
+		},
+	}
+
+	err = spark.SubmitJob(&job)
+	if err != nil {
+		return err
+	}
+
+	err = spark.WaitUntilSucceeded(job)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -55,10 +55,13 @@ func TestShuffleAppDriverOutput(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
-	spark.WaitForOutput(job, fmt.Sprintf("Groups count: %d", expectedGroupCount))
+	err = spark.WaitForOutput(job, fmt.Sprintf("Groups count: %d", expectedGroupCount))
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestRunningAppDeletion(t *testing.T) {
@@ -74,6 +77,9 @@ func TestRunningAppDeletion(t *testing.T) {
 	job := utils.SparkJob{
 		Name:     jobName,
 		Template: "spark-mock-task-runner-job.yaml",
+		Params: map[string]interface{}{
+			"args": []string{"1", "600"},
+		},
 	}
 	expectedExecutorCount := 1
 

--- a/tests/templates/spark-linear-regression-job.yaml
+++ b/tests/templates/spark-linear-regression-job.yaml
@@ -32,7 +32,7 @@ spec:
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}
-    serviceAccount: spark-driver
+    serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
     instances: 1

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -10,9 +10,8 @@ spec:
   imagePullPolicy: Always
   mainClass: MockTaskRunner
   mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
-  arguments:
-    - "1"
-    - "600"
+  arguments: {{ range $i, $arg := index .Params "args" }}
+  - "{{ $arg }}"{{ end }}
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
@@ -25,7 +24,7 @@ spec:
     labels:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
-    serviceAccount: spark-driver
+    serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
     instances: 1

--- a/tests/templates/spark-shuffle-job.yaml
+++ b/tests/templates/spark-shuffle-job.yaml
@@ -10,7 +10,7 @@ spec:
   imagePullPolicy: Always
   mainClass: ShuffleApp
   mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
-  arguments:{{ range $i, $arg := index .Params "args" }}
+  arguments: {{ range $i, $arg := index .Params "args" }}
     - "{{ $arg }}"{{ end }}
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "3m"
@@ -24,7 +24,7 @@ spec:
     labels:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
-    serviceAccount: spark-driver
+    serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
     instances: {{ index .Params "executor_count" }}

--- a/tests/utils/job.go
+++ b/tests/utils/job.go
@@ -6,12 +6,13 @@ import (
 )
 
 type SparkJob struct {
-	Name         string
-	Namespace    string
-	Image        string
-	SparkVersion string
-	Template     string
-	Params       map[string]interface{}
+	Name           string
+	Namespace      string
+	Image          string
+	SparkVersion   string
+	Template       string
+	ServiceAccount string
+	Params         map[string]interface{}
 }
 
 func (spark *SparkOperatorInstallation) SubmitJob(job *SparkJob) error {
@@ -25,6 +26,9 @@ func (spark *SparkOperatorInstallation) SubmitJob(job *SparkJob) error {
 	}
 	if job.SparkVersion == "" {
 		job.SparkVersion = SparkVersion
+	}
+	if job.ServiceAccount == "" {
+		job.ServiceAccount = spark.InstanceName + "-spark-service-account"
 	}
 
 	yamlFile := createSparkJob(*job)

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -14,18 +14,15 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"os/exec"
 	"strings"
-	"time"
 )
-
-const namespaceDeletionTimeout = 5 * time.Minute
-const namespaceDeletionCheckInterval = 3 * time.Second
 
 /* client-go util methods */
 
 func GetK8sClientSet() (*kubernetes.Clientset, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", KubeConfig)
 	if err != nil {
-		panic(err.Error())
+		log.Errorf("Can't build config [kubeconfig = %s]: %s", KubeConfig, err)
+		return nil, err
 	}
 
 	return kubernetes.NewForConfig(config)
@@ -53,6 +50,7 @@ func DropNamespace(clientSet *kubernetes.Clientset, name string) error {
 
 	err := clientSet.CoreV1().Namespaces().Delete(name, &options)
 	if err != nil {
+		log.Errorf("Can't delete namespace '%s':%s", name, err)
 		return err
 	}
 
@@ -67,6 +65,17 @@ func DropNamespace(clientSet *kubernetes.Clientset, name string) error {
 			return nil
 		}
 	})
+}
+
+func CreateServiceAccount(clientSet *kubernetes.Clientset, name string, namespace string) error {
+	log.Infof("Creating a service account %s/%s", namespace, name)
+	sa := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	_, err := clientSet.CoreV1().ServiceAccounts(namespace).Create(&sa)
+	return err
 }
 
 func getPodLog(clientSet *kubernetes.Clientset, namespace string, pod string, tailLines int64) (string, error) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60350](https://jira.mesosphere.com/browse/DCOS-60350)
Adds tests for the following cases related to service account creation
- Verify that default configuration creates service accounts for the operator and spark jobs
- Verify that createOperatorServiceAccount=false configuration works with a provided service account
- Verify that createSparkServiceAccount=false configuration works with a provided service account

### How were the changes tested?
In a stand-alone AWS k8s cluster, with `make test`.