### PR TITLE
Scale test scripts updates to support Terasort benchmark, improved S3 write time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 *.iml
+.DS_Store
+
 *.pem
 *.pub
 *cluster.yaml

--- a/scale-tests/README.md
+++ b/scale-tests/README.md
@@ -15,20 +15,34 @@ Scale Tests Tooling
 ## Scripts
 Scripts rely on the naming conventions to deploy and remove the resources:
 - [install.sh](scripts/install.sh) creates N namespaces and installs an operator instance in each
-- [run.sh](scripts/run.sh) generates specs for M SparkApplication per namespace and submits them to N namespaces
+- [scale_test.sh](scripts/scale_test.sh) generates specs for M scale-test SparkApplications per namespace and submits them to N namespaces
+- [terasort.sh](scripts/terasort.sh) runs a single TeraSort SparkApplication in a specified namespace
 - [uninstall.sh](scripts/uninstall.sh) deletes N namespaces
 
-Example:
+Scale test example:
 ```bash
 # Deploy CRDs, create 2 namespaces and create an operator instance in each
 ./scripts/install.sh 2
 
 # Submit 2 applications to 2 operator instances
-./scripts/run.sh 2 2
+./scripts/scale_test.sh 2 2
 
 # Observe metrics and alerts and uninstall operators
 # Delete operator instances, namespaces, and CRDs
 ./scripts/uninstall.sh 2
+```
+
+TeraSort example:
+```bash
+# Deploy CRDs, create 1 namespaces and create an operator instance
+./scripts/install.sh 1
+
+# Submit TeraSort benchmark to the Operator instance
+./scripts/terasort.sh spark-1 s3a://bucket/input s3a://bucket/output
+
+# Observe metrics and alerts and uninstall operators
+# Delete operator instances, namespaces, and CRDs
+./scripts/uninstall.sh 1
 ```
 
 ## Dashboards

--- a/scale-tests/scripts/scale_test.sh
+++ b/scale-tests/scripts/scale_test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#
+# This script submits multiple noop Spark Applications exercising allocation and CPU usage.
 
 set -ex
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
@@ -8,18 +10,22 @@ PROJECT_ROOT_DIR="$(dirname "${SCALE_TESTS_DIR}")"
 TEMPLATES_DIR="${SCALE_TESTS_DIR}/templates"
 
 NAMESPACE_PREFIX=${NAMESPACE_PREFIX:-spark}
-APP_NAME_PREFIX=${APP_NAME_PREFIX:-spark-sort}
+APP_NAME_PREFIX=${APP_NAME_PREFIX:-spark-mtr}
+SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-spark-service-account}
 
-S3_PATH=${S3_PATH:-spark-sort}
-NUM_EXECUTORS=${NUM_EXECUTORS:-4}
+# To achieve even executors utilization and predictable application duration,
+# NUM_EXECUTORS should be equal to NUM_TASKS. In this case end-to-end duration
+# of the application will be TASK_DURATION_SEC
+NUM_EXECUTORS=${NUM_EXECUTORS:-1}
+NUM_TASKS=${NUM_TASKS:-1}
+TASK_DURATION_SEC=${TASK_DURATION_SEC:-1800}
+
 
 if [[ $# -lt 2 ]]; then
   echo "Usage:" >&2
   echo "  $0 <number of applications to create> <number of namespaces to submit apps to>" >&2
   exit 1
 fi
-
-. ${SCRIPT_DIR}/aws_credentials.sh
 
 for n in $(seq ${2}); do
     NAMESPACE="${NAMESPACE_PREFIX}-${n}"
@@ -28,14 +34,12 @@ for n in $(seq ${2}); do
     for i in $(seq ${1}); do
       SPARK_APP_NAME="${APP_NAME_PREFIX}-ns-${n}-${i}"
 
-      APP_SPEC=$(cat ${TEMPLATES_DIR}/sort-application.tmpl \
-        | sed "s|AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID:-}|" \
-        | sed "s|AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY:-}|" \
-        | sed "s|AWS_SESSION_TOKEN|${AWS_SESSION_TOKEN:-}|" \
-        | sed "s|S3_ENDPOINT|${S3_ENDPOINT}|" \
+      APP_SPEC=$(cat ${TEMPLATES_DIR}/scale-test-application.tmpl \
         | sed "s|SPARK_APP_NAME|${SPARK_APP_NAME}|" \
+        | sed "s|SERVICE_ACCOUNT_NAME|${SERVICE_ACCOUNT_NAME}|" \
         | sed "s|NUM_EXECUTORS|${NUM_EXECUTORS}|" \
-        | sed "s|S3_PATH|${S3_PATH}|")
+        | sed "s|NUM_TASKS|${NUM_TASKS}|" \
+        | sed "s|TASK_DURATION_SEC|${TASK_DURATION_SEC}|")
 
         MULTI_APP_SPEC=${MULTI_APP_SPEC}$'\n'"---"$'\n'"${APP_SPEC}"
     done

--- a/scale-tests/scripts/terasort.sh
+++ b/scale-tests/scripts/terasort.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# This script runs a dataset generator for sorting benchmark and requires Spark Operator to be installed
+# This script submits a sorting application and requires Spark Operator to be installed.
+# Dataset should be generated upfront.
 
 set -ex
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
@@ -14,7 +15,7 @@ SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-spark-service-account}
 
 if [[ $# -lt 2 ]]; then
   echo "Usage:" >&2
-  echo "  $0 <namespace> <target s3 path>" >&2
+  echo "  $0 <namespace> <S3 source path> <S3 target path>" >&2
   exit 1
 fi
 
@@ -23,12 +24,13 @@ NUM_EXECUTORS=${NUM_EXECUTORS:-100}
 
 . ${SCRIPT_DIR}/aws_credentials.sh
 
-cat ${TEMPLATES_DIR}/gensort-application.tmpl \
+cat ${TEMPLATES_DIR}/sort-application.tmpl \
   | sed "s|AWS_ACCESS_KEY_ID|${AWS_ACCESS_KEY_ID:-}|" \
   | sed "s|AWS_SECRET_ACCESS_KEY|${AWS_SECRET_ACCESS_KEY:-}|" \
   | sed "s|AWS_SESSION_TOKEN|${AWS_SESSION_TOKEN:-}|" \
   | sed "s|S3_ENDPOINT|${S3_ENDPOINT}|" \
   | sed "s|SERVICE_ACCOUNT_NAME|${SERVICE_ACCOUNT_NAME}|" \
   | sed "s|NUM_EXECUTORS|${NUM_EXECUTORS}|" \
-  | sed "s|TARGET_S3_PATH|${2:-}|" \
+  | sed "s|SOURCE_PATH|${2:-}|" \
+  | sed "s|TARGET_PATH|${3:-}|" \
   | kubectl --namespace "${NAMESPACE}" apply -f -

--- a/scale-tests/scripts/uninstall.sh
+++ b/scale-tests/scripts/uninstall.sh
@@ -21,6 +21,3 @@ for i in $(seq ${1}); do
     kubectl delete --namespace "${NAMESPACE}" instance "${INSTANCE_NAME_PREFIX}-${i}"
     kubectl delete namespace "${NAMESPACE}"
 done
-
-echo "Deleting CRDs"
-kubectl delete -f ${SPECS_DIR}/spark-applications-crds.yaml

--- a/scale-tests/templates/gensort-application.tmpl
+++ b/scale-tests/templates/gensort-application.tmpl
@@ -15,9 +15,9 @@ spec:
     - "--num-records"
     - "1000000"
     - "--static-prefix-length"
-    - "120"
+    - "128"
     - "--random-suffix-length"
-    - "8"
+    - "128"
     - "--value-size-bytes"
     - "1000000"
     - "--output-path"
@@ -27,6 +27,7 @@ spec:
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
     "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
     "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
+    "spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version": "2"
     "spark.hadoop.fs.s3a.endpoint": "S3_ENDPOINT"
     "spark.hadoop.fs.s3a.access.key": "AWS_ACCESS_KEY_ID"
     "spark.hadoop.fs.s3a.secret.key": "AWS_SECRET_ACCESS_KEY"
@@ -39,7 +40,7 @@ spec:
     memory: "1g"
     labels:
       version: 2.4.3
-    serviceAccount: spark-driver
+    serviceAccount: SERVICE_ACCOUNT_NAME
   executor:
     cores: 1
     instances: NUM_EXECUTORS

--- a/scale-tests/templates/monitoring.tmpl
+++ b/scale-tests/templates/monitoring.tmpl
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-operator-metrics
+  labels:
+    "spark/servicemonitor": "true"
+spec:
+  ports:
+    - port: 10254
+      name: metrics
+  clusterIP: None
+  selector:
+    "app.kubernetes.io/name": spark
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spark-application-metrics
+  labels:
+    "spark/servicemonitor": "true"
+spec:
+  ports:
+    - port: 8090
+      name: metrics
+  clusterIP: None
+  selector:
+    "metrics-exposed": "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: prometheus-operator
+    release: prometheus-kubeaddons
+  name: spark-cluster-monitor
+spec:
+  endpoints:
+    - interval: 5s
+      port: metrics
+  selector:
+    matchLabels:
+      spark/servicemonitor: "true"

--- a/scale-tests/templates/scale-test-application.tmpl
+++ b/scale-tests/templates/scale-test-application.tmpl
@@ -1,0 +1,40 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: SPARK_APP_NAME
+spec:
+  type: Scala
+  mode: cluster
+  image: mesosphere/spark:2.4.3-bin-hadoop2.9-k8s
+  imagePullPolicy: Always
+  mainClass: MockTaskRunner
+  mainApplicationFile: "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/scale-tests-spark-2.4.3-20191101.jar"
+  arguments:
+    - "NUM_TASKS"
+    - "TASK_DURATION_SEC"
+  sparkConf:
+    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
+    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
+  sparkVersion: "2.4.3"
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    memory: "2g"
+    labels:
+      version: 2.4.3
+      metrics-exposed: "true"
+    serviceAccount: spark-service-account
+  executor:
+    cores: 1
+    instances: NUM_EXECUTORS
+    memory: "1g"
+    labels:
+      version: 2.4.3
+      metrics-exposed: "true"
+  monitoring:
+    exposeDriverMetrics: true
+    exposeExecutorMetrics: true
+    prometheus:
+      jmxExporterJar: "/prometheus/jmx_prometheus_javaagent-0.11.0.jar"
+      port: 8090

--- a/scale-tests/templates/service-account.tmpl
+++ b/scale-tests/templates/service-account.tmpl
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: SERVICE_ACCOUNT_NAME
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-driver-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["*"]

--- a/scale-tests/templates/sort-application.tmpl
+++ b/scale-tests/templates/sort-application.tmpl
@@ -1,39 +1,43 @@
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
-  name: SPARK_APP_NAME
+  name: spark-terasort
 spec:
   type: Scala
   mode: cluster
   image: mesosphere/spark:2.4.3-bin-hadoop2.9-k8s
   imagePullPolicy: Always
   mainClass: sorting.SortingApp
-  mainApplicationFile: "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/scale-tests-spark-2.4.3-20191017.jar"
+  mainApplicationFile: "https://infinity-artifacts.s3-us-west-2.amazonaws.com/spark/scale-tests-spark-2.4.3-20191104-sorting.jar"
   arguments:
-    - "S3_PATH"
+    - "SOURCE_PATH"
+    - "TARGET_PATH"
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
     "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
     "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
+    "spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version": "2"
     "spark.hadoop.fs.s3a.endpoint": "S3_ENDPOINT"
     "spark.hadoop.fs.s3a.access.key": "AWS_ACCESS_KEY_ID"
     "spark.hadoop.fs.s3a.secret.key": "AWS_SECRET_ACCESS_KEY"
     "spark.hadoop.fs.s3a.session.token": "AWS_SESSION_TOKEN"
+    "spark.kubernetes.memoryOverheadFactor": "0.5"
+    "spark.driver.maxResultSize": "4g"
   sparkVersion: "2.4.3"
   restartPolicy:
     type: Never
   driver:
     cores: 2
-    memory: "2g"
+    memory: "6g"
     labels:
       version: 2.4.3
       metrics-exposed: "true"
-    serviceAccount: spark-driver
+    serviceAccount: SERVICE_ACCOUNT_NAME
   executor:
     cores: 1
     instances: NUM_EXECUTORS
-    memory: "3g"
+    memory: "8g"
     labels:
       version: 2.4.3
       metrics-exposed: "true"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60318: Improve gensort job to avoid high latencies while writing to S3](https://jira.mesosphere.com/browse/DCOS-60318)

Originally started as gensort write time improvement which is achieved via committer configuration property:
```
"spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version": "2"
```
This PR includes refactoring to separate scale tests from the sort benchmark and introduces changes to support ongoing work in https://github.com/mesosphere/spark-build/pull/559 and https://github.com/mesosphere/spark-build/pull/560

### Why are the changes needed?
These changes are needed to support new scale tests objectives and run the workloads separately.

### How were the changes tested?
* by running `gensort` job on a cluster with 40 executors and verifying 1TiB dataset is generated in under 1 hour
* by running all the scripts against private cluster to test changes from https://github.com/mesosphere/spark-build/pull/559 and https://github.com/mesosphere/spark-build/pull/560
