### PR TITLE
Removing metrics service from components check in multitenancy tests

### DIFF
--- a/tests/tenancy_test.go
+++ b/tests/tenancy_test.go
@@ -73,7 +73,7 @@ func TestTenancyTwoOperatorsSameNameDifferentNamespaces(t *testing.T) {
 
 func verifyComponents(t *testing.T, operators []*utils.SparkOperatorInstallation) {
 	serviceAccounts := []string{"spark-operator-service-account", "spark-service-account"}
-	services := []string{"spark-webhook", "spark-operator-metrics"}
+	services := []string{"spark-webhook"}
 
 	for _, operator := range operators {
 		for _, service := range services {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes a check for metrics service from multi-tenancy tests as it is not installed as a part of KUDO Spark.

### Why are the changes needed?
After the changes introduced in https://github.com/mesosphere/kudo-spark-operator/pull/48 we removed metrics service installation from KUDO, however, were still verifying it is installed in the tests.

### How were the changes tested?
* integration tests from this repo