### PR TITLE
Operator upgrade to KUDO 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Required software:
 * GNU Make 4.2.1 or higher
 * sha1sum
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.5 or higher
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.8.0 or higher
 
 For test cluster provisioning and Stub Universe artifacts upload valid AWS access credentials required:
 * `AWS_PROFILE` **or** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables should be provided
@@ -55,7 +55,7 @@ OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:spark-2.4.3-hadoop-2.9-k
 
 * Kubernetes cluster up and running
 * `kubectl` configured to work with provisioned cluster
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.5 or higher
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.8.0 or higher
 
 ### Installation
 

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.13.0@sha256:de697ce5ae02f3d9a57b0603fbb648efadfa212727e702ad3a807b43eba7f6d6
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl && \
+ARG KUDO_DOWNLOAD_URL=https://github.com/kudobuilder/kudo/releases/download/v0.8.0-pre.2/kubectl-kudo_0.8.0-pre.2_linux_x86_64
+ARG KUBECTL_DOWNLOAD_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
+
+RUN curl -LO ${KUBECTL_DOWNLOAD_URL} && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
-    curl -L https://github.com/kudobuilder/kudo/releases/download/v0.7.5/kubectl-kudo_0.7.5_linux_x86_64 -o /go/bin/kubectl-kudo && \
+    curl -L ${KUDO_DOWNLOAD_URL} -o /go/bin/kubectl-kudo && \
     chmod +x /go/bin/kubectl-kudo && \
     go get github.com/2tvenom/go-test-teamcity

--- a/kudo-operator/docs/latest/README.md
+++ b/kudo-operator/docs/latest/README.md
@@ -6,7 +6,6 @@ KUDO Spark latest
 * [Submitting Spark applications](./submission.md)
 * [Monitoring](./monitoring.md)
 * [Spark History Server](./history-server.md)
-* [Multi-tenancy](./multi-tenancy.md)
 * [Release notes](./release-notes.md)
 * [Limitations](./limitations.md)
 * [Versions](./versions.md)

--- a/kudo-operator/docs/latest/history-server.md
+++ b/kudo-operator/docs/latest/history-server.md
@@ -5,7 +5,7 @@ Spark History Server Configuration
 
 Required software:
 * K8s cluster
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.7.5 or higher
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.8.0 or higher
 
 ## Installing Spark Operator with History Server Enabled
 

--- a/kudo-operator/docs/latest/multi-tenancy.md
+++ b/kudo-operator/docs/latest/multi-tenancy.md
@@ -1,2 +1,0 @@
-KUDO Spark Operator Multi-tenancy
----

--- a/kudo-operator/docs/latest/versions.md
+++ b/kudo-operator/docs/latest/versions.md
@@ -8,4 +8,4 @@ Versions
 * Prometheus Java agent 0.11.0
 
 ## KUDO Version Requirement
-* KUDO version 0.7.5 or later
+* KUDO version 0.8.0 or later

--- a/kudo-operator/operator/operator.yaml
+++ b/kudo-operator/operator/operator.yaml
@@ -1,6 +1,7 @@
+apiVersion: kudo.dev/v1beta1
 name: "spark"
-version: "0.0.1"
-kudoVersion: 0.7.5
+version: "beta1"
+kudoVersion: 0.8.0
 kubernetesVersion: 1.15.0
 appVersion: "2.4.3"
 maintainers:
@@ -10,18 +11,20 @@ maintainers:
     email: ukrautsou.c@d2iq.com
 url: https://spark.apache.org/
 tasks:
-  deploy:
-    resources:
-      - spark-operator-crds.yaml
-      - spark-operator-rbac.yaml
-      - spark-operator-serviceaccount.yaml
-      - spark-rbac.yaml
-      - spark-serviceaccount.yaml
-      - webhook-init-job.yaml
-      - spark-operator-deployment.yaml
-      - webhook-service.yaml
-      - spark-history-server-deployment.yaml
-      - spark-history-server-service.yaml
+  - name: deploy
+    kind: Apply
+    spec:
+      resources:
+        - spark-operator-crds.yaml
+        - spark-operator-rbac.yaml
+        - spark-operator-serviceaccount.yaml
+        - spark-rbac.yaml
+        - spark-serviceaccount.yaml
+        - webhook-init-job.yaml
+        - spark-operator-deployment.yaml
+        - webhook-service.yaml
+        - spark-history-server-deployment.yaml
+        - spark-history-server-service.yaml
 
 plans:
   deploy:

--- a/kudo-operator/operator/params.yaml
+++ b/kudo-operator/operator/params.yaml
@@ -1,165 +1,150 @@
-# Service Accounts and RBAC
-operatorServiceAccountName:
-  description: "Service Account for Spark Operator"
-  default: "spark-operator-service-account"
-  displayName: "Operator Service Account"
+apiVersion: kudo.dev/v1beta1
+parameters:
+  # Service Accounts and RBAC
+  - name: operatorServiceAccountName
+    description: "Service Account for Spark Operator"
+    default: "spark-operator-service-account"
+    displayName: "Operator Service Account"
 
-createOperatorServiceAccount:
-  description: "Automatically create Service Account for Spark Operator"
-  default: true
-  displayName: "Auto Create Operator Service Account"
+  - name: createOperatorServiceAccount
+    description: "Automatically create Service Account for Spark Operator"
+    default: true
+    displayName: "Auto Create Operator Service Account"
 
-sparkServiceAccountName:
-  description: "Use Service Account for Spark Drivers"
-  default: "spark-service-account"
-  displayName: "Spark Drivers Service Account"
+  - name: sparkServiceAccountName
+    description: "Use Service Account for Spark Drivers"
+    default: "spark-service-account"
+    displayName: "Spark Drivers Service Account"
 
-createSparkServiceAccount:
-  description: "Automatically generate Service Account for Spark Drivers"
-  default: true
-  displayName: "Auto Create Service Account for Spark Drivers"
+  - name: createSparkServiceAccount
+    description: "Automatically generate Service Account for Spark Drivers"
+    default: true
+    displayName: "Auto Create Service Account for Spark Drivers"
 
-createRBAC:
-  description: "Automatically create RBAC for Spark Operator and Drivers"
-  default: true
-  displayName: "Auto Create RBAC for Spark Operator and Drivers"
+  - name: createRBAC
+    description: "Automatically create RBAC for Spark Operator and Drivers"
+    default: true
+    displayName: "Auto Create RBAC for Spark Operator and Drivers"
 
-# Docker image
-operatorImageName:
-  description: "Operator Docker image name"
-  default: mesosphere/kudo-spark-operator
-  displayName: "Operator Docker image name"
+  # Docker image
+  - name: operatorImageName
+    description: "Operator Docker image name"
+    default: mesosphere/kudo-spark-operator
+    displayName: "Operator Docker image name"
 
-operatorVersion:
-  description: "Operator Docker image version (tag)"
-  default: latest
-  displayName: "Operator Docker image version (tag)"
+  - name: operatorVersion
+    description: "Operator Docker image version (tag)"
+    default: latest
+    displayName: "Operator Docker image version (tag)"
 
-imagePullPolicy:
-  description: "Image pull policy"
-  default: Always
-  displayName: "Image pull policy"
+  - name: imagePullPolicy
+    description: "Image pull policy"
+    default: Always
+    displayName: "Image pull policy"
 
-## Metrics
-enableMetrics:
-  description: "Enable metrics"
-  default: true
-  displayName: "Enable metrics"
+  ## Metrics
+  - name: enableMetrics
+    description: "Enable metrics"
+    default: true
+    displayName: "Enable metrics"
 
-operatorMetricsPort:
-  description: "Spark Operator Metrics port"
-  default: 10254
-  displayName: "Spark Operator Metrics port"
+  - name: operatorMetricsPort
+    description: "Spark Operator Metrics port"
+    default: 10254
+    displayName: "Spark Operator Metrics port"
 
-metricsEndpoint:
-  description: "Metrics endpoint"
-  default: "/metrics"
-  displayName: "Metrics endpoint"
+  - name: metricsEndpoint
+    description: "Metrics endpoint"
+    default: "/metrics"
+    displayName: "Metrics endpoint"
 
-metricsPrefix:
-  description: "Metrics prefix"
-  default: ""
-  displayName: "Metrics prefix"
+  - name: metricsPrefix
+    description: "Metrics prefix"
+    default: ""
+    displayName: "Metrics prefix"
 
-resyncIntervalSeconds:
-  description: "Informer resync interval in seconds"
-  default: 30
-  displayName: "Informer resync interval in seconds"
+  - name: resyncIntervalSeconds
+    description: "Informer resync interval in seconds"
+    default: 30
+    displayName: "Informer resync interval in seconds"
 
-# History Server
-enableHistoryServer:
-  description: "Start Spark History Server"
-  default: false
-  displayName: "Enable Spark History Server"
+  # History Server
+  - name: enableHistoryServer
+    description: "Start Spark History Server"
+    default: false
+    displayName: "Enable Spark History Server"
 
-historyServerFsLogDirectory:
-  description: "Spark EventLog Directory from which to load events for prior Spark job runs (e.g., hdfs://hdfs/ or s3a://path/to/bucket). Note: You'd typically want to set this to point to distributed/HA storage"
-  default: ""
-  displayName: "Spark History Server Event Log Directory"
+  - name: historyServerFsLogDirectory
+    description: "Spark EventLog Directory from which to load events for prior Spark job runs (e.g., hdfs://hdfs/ or s3a://path/to/bucket). Note: You'd typically want to set this to point to distributed/HA storage"
+    default: ""
+    displayName: "Spark History Server Event Log Directory"
 
-historyServerCleanerEnabled:
-  description: "Specifies whether the Spark History Server should periodically clean up event logs from storage."
-  default: "false"
-  displayName: "Spark History Server Cleaner Enabled"
+  - name: historyServerCleanerEnabled
+    description: "Specifies whether the Spark History Server should periodically clean up event logs from storage."
+    default: "false"
+    displayName: "Spark History Server Cleaner Enabled"
 
-historyServerCleanerInterval:
-  description: "Frequency the Spark History Server checks for files to delete."
-  default: "1d"
-  displayName: "Spark History Server Cleaner Interval"
+  - name: historyServerCleanerInterval
+    description: "Frequency the Spark History Server checks for files to delete."
+    default: "1d"
+    displayName: "Spark History Server Cleaner Interval"
 
-historyServerCleanerMaxAge:
-  description: "History files older than this will be deleted."
-  default: "7d"
-  displayName: "Spark History Server Cleaner Max Age"
+  - name: historyServerCleanerMaxAge
+    description: "History files older than this will be deleted."
+    default: "7d"
+    displayName: "Spark History Server Cleaner Max Age"
 
-historyServerOpts:
-  description: "Extra options to pass to the Spark History Server"
-  default: ""
-  displayName: "Spark History Server Options"
+  - name: historyServerOpts
+    description: "Extra options to pass to the Spark History Server"
+    default: ""
+    displayName: "Spark History Server Options"
 
-historyServerPVCName:
-  description: "External Persistent Volume Claim Name used for Spark event logs storage by History Server"
-  default: ""
-  displayName: "Spark History Server Persistent Volume Claim Name"
+  - name: historyServerPVCName
+    description: "External Persistent Volume Claim Name used for Spark event logs storage by History Server"
+    default: ""
+    displayName: "Spark History Server Persistent Volume Claim Name"
 
-## Miscellaneous
-sparkJobNamespace:
-  description: "Namespace for Spark Applications. Defaults to Operator namespace"
-  default: ""
-  displayName: "Namespace for Spark Applications"
+  ## Miscellaneous
+  - name: sparkJobNamespace
+    description: "Namespace for Spark Applications. Defaults to Operator namespace"
+    default: ""
+    displayName: "Namespace for Spark Applications"
 
-enableWebhook:
-  description: "Enable webhook"
-  default: true
-  displayName: "Enable webhook"
+  - name: enableWebhook
+    description: "Enable webhook"
+    default: true
+    displayName: "Enable webhook"
 
-webhookPort:
-  description: "Webhook port"
-  default: 8080
-  displayName: "Webhook port"
+  - name: webhookPort
+    description: "Webhook port"
+    default: 8080
+    displayName: "Webhook port"
 
-controllerThreads:
-  description: "Controller threads"
-  default: 10
-  displayName: "Controller threads"
+  - name: controllerThreads
+    description: "Controller threads"
+    default: 10
+    displayName: "Controller threads"
 
-ingressUrlFormat:
-  description: "Ingress URL format"
-  default: ""
-  displayName: "Ingress URL format"
+  - name: ingressUrlFormat
+    description: "Ingress URL format"
+    default: ""
+    displayName: "Ingress URL format"
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-## TODO: should be a map
-nodeSelector:
-  default: ""
+  ## Output verbosity and debugging level
+  ## Ref: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
+  - name: logLevel
+    description: "Log Level"
+    default: 2
+    displayName: "Log Level"
 
-## Resources for the sparkoperator deployment
-## Ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-## TODO: should be a map
-resources:
-  default: ""
+  ## Whether to enable batch scheduler for pod scheduling,
+  ## if enabled, end user can specify batch scheduler name in spark application.
+  - name: enableBatchScheduler
+    description: "Enable Batch Scheduler"
+    default: false
+    displayName: "Enable Batch Scheduler"
 
-## TODO: should be a map
-podAnnotations:
-  default: ""
-
-
-## Output verbosity and debugging level
-## Ref: https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
-logLevel:
-  description: "Log Level"
-  default: 2
-  displayName: "Log Level"
-
-## Whether to enable batch scheduler for pod scheduling,
-## if enabled, end user can specify batch scheduler name in spark application.
-enableBatchScheduler:
-  description: "Enable Batch Scheduler"
-  default: false
-  displayName: "Enable Batch Scheduler"
-
-installCrds:
-  description: "Install sparkapplications.sparkoperator.k8s.io and scheduledsparkapplications.sparkoperator.k8s.io"
-  default: true
-  displayName: "Install Spark Operator CRDs"
+  - name: installCrds
+    description: "Install sparkapplications.sparkoperator.k8s.io and scheduledsparkapplications.sparkoperator.k8s.io"
+    default: true
+    displayName: "Install Spark Operator CRDs"

--- a/kudo-operator/operator/templates/spark-history-server-deployment.yaml
+++ b/kudo-operator/operator/templates/spark-history-server-deployment.yaml
@@ -5,14 +5,14 @@ metadata:
   name: {{ .Name }}-history-server
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}-history-server
+    app.kubernetes.io/name: {{ .OperatorName }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Name }}-history-server
+      app.kubernetes.io/name: {{ .OperatorName }}-history-server
       app.kubernetes.io/instance: {{ .Name }}
       app.kubernetes.io/version: {{ .Params.operatorVersion }}
   strategy:
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ .Name }}-history-server
+        app.kubernetes.io/name: {{ .OperatorName }}-history-server
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/version: {{ .Params.operatorVersion }}
     spec:

--- a/kudo-operator/operator/templates/spark-history-server-deployment.yaml
+++ b/kudo-operator/operator/templates/spark-history-server-deployment.yaml
@@ -2,17 +2,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: history-server
+  name: {{ .Name }}-history-server
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: history-server
+    app.kubernetes.io/name: {{ .Name }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: history-server
+      app.kubernetes.io/name: {{ .Name }}-history-server
       app.kubernetes.io/instance: {{ .Name }}
       app.kubernetes.io/version: {{ .Params.operatorVersion }}
   strategy:
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: history-server
+        app.kubernetes.io/name: {{ .Name }}-history-server
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/version: {{ .Params.operatorVersion }}
     spec:

--- a/kudo-operator/operator/templates/spark-history-server-service.yaml
+++ b/kudo-operator/operator/templates/spark-history-server-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Name }}-history-server
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}-history-server
+    app.kubernetes.io/name: {{ .OperatorName }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
@@ -13,7 +13,7 @@ spec:
   - port: 18080
     name: history-server
   selector:
-    app.kubernetes.io/name: {{ .Name }}-history-server
+    app.kubernetes.io/name: {{ .OperatorName }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 {{- end }}

--- a/kudo-operator/operator/templates/spark-history-server-service.yaml
+++ b/kudo-operator/operator/templates/spark-history-server-service.yaml
@@ -2,17 +2,18 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: history-server
+  name: {{ .Name }}-history-server
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: history-server
+    app.kubernetes.io/name: {{ .Name }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
+    app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
   ports:
   - port: 18080
     name: history-server
   selector:
-    app.kubernetes.io/name: history-server
+    app.kubernetes.io/name: {{ .Name }}-history-server
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 {{- end }}

--- a/kudo-operator/operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/operator/templates/spark-operator-deployment.yaml
@@ -7,17 +7,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .OperatorName }}
+  name: {{ .Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .OperatorName }}
+      app.kubernetes.io/name: {{ .Name }}
       app.kubernetes.io/instance: {{ .Name }}
       app.kubernetes.io/version: {{ .Params.operatorVersion }}
   strategy:
@@ -31,7 +31,7 @@ spec:
         prometheus.io/path: {{ .Params.metricsEndpoint }}
     {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .OperatorName }}
+        app.kubernetes.io/name: {{ .Name }}
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/version: {{ .Params.operatorVersion }}
       initializers:

--- a/kudo-operator/operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/operator/templates/spark-operator-deployment.yaml
@@ -10,14 +10,14 @@ metadata:
   name: {{ .Name }}
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}
+    app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Name }}
+      app.kubernetes.io/name: {{ .OperatorName }}
       app.kubernetes.io/instance: {{ .Name }}
       app.kubernetes.io/version: {{ .Params.operatorVersion }}
   strategy:
@@ -31,7 +31,7 @@ spec:
         prometheus.io/path: {{ .Params.metricsEndpoint }}
     {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Name }}
+        app.kubernetes.io/name: {{ .OperatorName }}
         app.kubernetes.io/instance: {{ .Name }}
         app.kubernetes.io/version: {{ .Params.operatorVersion }}
       initializers:

--- a/kudo-operator/operator/templates/spark-operator-rbac.yaml
+++ b/kudo-operator/operator/templates/spark-operator-rbac.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Namespace }}-cr
+  name: {{ .Name }}-{{ .Namespace }}-cr
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-{{ .Namespace }}-cr
     app.kubernetes.io/instance: {{ .Name }}
 rules:
 - apiGroups: [""]
@@ -42,9 +42,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Namespace }}-crb
+  name: {{ .Name }}-{{ .Namespace }}-crb
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-{{ .Namespace }}-crb
     app.kubernetes.io/instance: {{ .Name }}
 subjects:
   - kind: ServiceAccount
@@ -56,6 +56,6 @@ subjects:
     namespace: {{ .Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Namespace }}-cr
+  name: {{ .Name }}-{{ .Namespace }}-cr
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/kudo-operator/operator/templates/spark-operator-serviceaccount.yaml
+++ b/kudo-operator/operator/templates/spark-operator-serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Params.operatorServiceAccountName }}
+  name: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-{{ .Params.operatorServiceAccountName }}
     app.kubernetes.io/instance: {{ .Name }}
 {{- end }}

--- a/kudo-operator/operator/templates/spark-rbac.yaml
+++ b/kudo-operator/operator/templates/spark-rbac.yaml
@@ -7,9 +7,9 @@ metadata:
   {{- else }}
   namespace: {{ .Namespace }}
   {{- end }}
-  name: spark-role
+  name: {{ .Name }}-spark-role
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-spark-role
     app.kubernetes.io/instance: {{ .Name }}
 rules:
   - apiGroups: [""]
@@ -22,14 +22,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: spark-role-binding
+  name: {{ .Name }}-spark-rb
   {{- if (ne .Params.sparkJobNamespace "") }}
   namespace: {{ .Params.sparkJobNamespace }}
   {{- else }}
   namespace: {{ .Namespace }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-spark-rb
     app.kubernetes.io/instance: {{ .Name }}
 subjects:
 - kind: ServiceAccount
@@ -45,6 +45,6 @@ subjects:
   {{- end }}
 roleRef:
   kind: Role
-  name: spark-role
+  name: {{ .Name }}-spark-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/kudo-operator/operator/templates/spark-serviceaccount.yaml
+++ b/kudo-operator/operator/templates/spark-serviceaccount.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Params.sparkServiceAccountName }}
+  name: {{ .Name }}-{{ .Params.sparkServiceAccountName }}
   {{- if (ne .Params.sparkJobNamespace "") }}
   namespace: {{ .Params.sparkJobNamespace }}
   {{- else }}
   namespace: {{ .Namespace }}
   {{- end }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-{{ .Params.sparkServiceAccountName }}
     app.kubernetes.io/instance: {{ .Name }}
 {{- end }}

--- a/kudo-operator/operator/templates/webhook-cleanup-job.yaml
+++ b/kudo-operator/operator/templates/webhook-cleanup-job.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .OperatorName }}-webhook-cleanup
+  name: {{ .Name }}-webhook-cleanup
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-webhook-cleanup
     app.kubernetes.io/instance: {{ .Name }}
 spec:
   template:

--- a/kudo-operator/operator/templates/webhook-init-job.yaml
+++ b/kudo-operator/operator/templates/webhook-init-job.yaml
@@ -2,10 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .OperatorName }}-init
+  name: {{ .Name }}-init
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-init
     app.kubernetes.io/instance: {{ .Name }}
 spec:
   template:
@@ -20,5 +20,5 @@ spec:
       - name: main
         image: {{ .Params.operatorImageName }}:{{ .Params.operatorVersion }}
         imagePullPolicy: {{ .Params.imagePullPolicy }}
-        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Namespace }}", "-s", "{{ .OperatorName }}-webhook", "-p"]
+        command: ["/usr/bin/gencerts.sh", "-n", "{{ .Namespace }}", "-s", "{{ .Name }}-webhook", "-p"]
 {{- end }}

--- a/kudo-operator/operator/templates/webhook-service.yaml
+++ b/kudo-operator/operator/templates/webhook-service.yaml
@@ -2,10 +2,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .OperatorName }}-webhook
+  name: {{ .Name }}-webhook
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}-webhook
     app.kubernetes.io/instance: {{ .Name }}
 spec:
   ports:
@@ -13,7 +13,7 @@ spec:
     targetPort: {{ .Params.webhookPort }}
     name: webhook
   selector:
-    app.kubernetes.io/name: {{ .OperatorName }}
+    app.kubernetes.io/name: {{ .Name }}
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 {{- end }}

--- a/kudo-operator/operator/templates/webhook-service.yaml
+++ b/kudo-operator/operator/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Name }}-webhook
   namespace: {{ .Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Name }}-webhook
+    app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
 spec:
   ports:
@@ -13,7 +13,7 @@ spec:
     targetPort: {{ .Params.webhookPort }}
     name: webhook
   selector:
-    app.kubernetes.io/name: {{ .Name }}
+    app.kubernetes.io/name: {{ .OperatorName }}
     app.kubernetes.io/instance: {{ .Name }}
     app.kubernetes.io/version: {{ .Params.operatorVersion }}
 {{- end }}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -150,7 +150,7 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	}
 
 	// Find out History Server POD name
-	instanceName := fmt.Sprint(utils.DefaultInstanceName, "-history-server")
+	instanceName := fmt.Sprint(utils.OperatorName, "-history-server")
 	historyServerPodName, err := utils.Kubectl(
 		"get",
 		"pods",

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -150,11 +150,12 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	}
 
 	// Find out History Server POD name
+	instanceName := fmt.Sprint(utils.DefaultInstanceName, "-history-server")
 	historyServerPodName, err := utils.Kubectl(
 		"get",
 		"pods",
 		"--namespace="+spark.Namespace,
-		"--output=jsonpath={.items[?(@.metadata.labels.app\\.kubernetes\\.io/name==\"history-server\")].metadata.name}",
+		"--output=jsonpath={.items[?(@.metadata.labels.app\\.kubernetes\\.io/name==\""+instanceName+"\")].metadata.name}",
 	)
 	if err != nil {
 		t.Error(err.Error())

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	gotest.tools v2.2.0+incompatible // indirect
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/tests/tenancy_test.go
+++ b/tests/tenancy_test.go
@@ -73,7 +73,7 @@ func TestTenancyTwoOperatorsSameNameDifferentNamespaces(t *testing.T) {
 
 func verifyComponents(t *testing.T, operators []*utils.SparkOperatorInstallation) {
 	serviceAccounts := []string{"spark-operator-service-account", "spark-service-account"}
-	services := []string{"spark-webhook"}
+	services := []string{"webhook"}
 
 	for _, operator := range operators {
 		for _, service := range services {

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -12,6 +12,7 @@ import (
 )
 
 const DefaultNamespace = "kudo-spark-operator-testing"
+const OperatorName = "spark"
 const DefaultInstanceName = "test-instance"
 const rootDirName = "tests"
 const cmdLogFormat = ">%s %v\n%s"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60787: Update Spark Operator to KUDO 0.8.x](https://jira.mesosphere.com/browse/DCOS-60787).

This PR updates KUDO version and adds necessary changes to templates, `params.yaml`, and `operator.yaml` to address the breaking changes introduced in KUDO 0.8.0.

### Why are the changes needed?
The changes were needed to address the breaking changes at the earlier stage and simplify later updates to the newer KUDO versions.

### How were the changes tested?
* by running `make test` locally
* integration tests from this repo run in [KUDO 0.8.0 CI job](https://teamcity.mesosphere.io/viewType.html?buildTypeId=Frameworks_DataServices_Kudo_Spark_Pr_SparkPrKonvoyKudoV080pre2&branch_Frameworks_DataServices_Kudo_Spark_Pr=pull%2F54&tab=buildTypeStatusDiv)
