### PR TITLE
[DCOS-60858] [Spark Operator] Test mounting secrets

### DIFF
--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -344,8 +344,11 @@ func runSecretTest(secretName string, secretPath string, secretKey string) (stri
 		return "", err
 	}
 
-	secretData := map[string]string{
-		secretKey: "secretValue",
+	secretData := make(map[string]string)
+	if secretKey != "" {
+		secretData[secretKey] = "secretValue"
+	} else {
+		secretData["secretKey"] = "secretValue"
 	}
 
 	err = utils.CreateSecret(client, secretName, spark.Namespace, secretData)

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -301,17 +301,16 @@ func runTestCase(tc securityTestCase) error {
 func TestEnvBasedSecret(t *testing.T) {
 	secretName := "env-based-secret"
 	secretKey := "secretKey"
-	secretEnv := "SECRET_ENV"
 	jobDescription, err := runSecretTest(secretName, "", secretKey)
 
 	if err != nil {
 		t.Error(err.Error())
 	}
 
-	if strings.Contains(jobDescription, fmt.Sprintf("%s from %s-volume", secretKey, secretName)) {
-		log.Infof("Successfully exported environment variable '%s' from secret '%s'", secretEnv, secretName)
+	if strings.Contains(jobDescription, fmt.Sprintf("set to the key '%s' in secret '%s'", secretKey, secretName)) {
+		log.Infof("Successfully set environment variable to the key '%s' in secret '%s'", secretKey, secretName)
 	} else {
-		t.Errorf("Unnable to export environment variable '%s' from secret '%s'", secretEnv, secretName)
+		t.Errorf("Unnable to set environment variable to the key '%s' in secret '%s'", secretKey, secretName)
 	}
 }
 

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -323,11 +323,6 @@ func runSecretTest(secretName string, secretPath string, secretKey string, expec
 		return err
 	}
 
-	client, err := utils.GetK8sClientSet()
-	if err != nil {
-		return err
-	}
-
 	secretData := make(map[string]string)
 	if secretKey != "" {
 		secretData[secretKey] = "secretValue"
@@ -335,7 +330,7 @@ func runSecretTest(secretName string, secretPath string, secretKey string, expec
 		secretData["secretKey"] = "secretValue"
 	}
 
-	err = utils.CreateSecret(client, secretName, spark.Namespace, secretData)
+	err = utils.CreateSecret(spark.K8sClients, secretName, spark.Namespace, secretData)
 	if err != nil {
 		return err
 	}
@@ -366,7 +361,7 @@ func runSecretTest(secretName string, secretPath string, secretKey string, expec
 		"describe",
 		"pod",
 		"--namespace="+spark.Namespace,
-		jobName+"-driver",
+		utils.DriverPodName(jobName),
 	)
 	if err != nil {
 		return err

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -25,6 +25,17 @@ spec:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
     serviceAccount: {{ .ServiceAccount }}
+    {{- if and .Params.SecretName .Params.SecretPath }}
+    secrets:
+    - name: {{ .Params.SecretName }}
+      path: {{ .Params.SecretPath }}
+      secretType: Opaque
+    {{- else if and .Params.SecretName .Params.SecretKey }}
+    envSecretKeyRefs:
+      SECRET_ENV:
+        name: {{ .Params.SecretName }}
+        key: {{ .Params.SecretKey }}
+    {{- end }}
   executor:
     cores: 1
     instances: 1
@@ -32,3 +43,14 @@ spec:
     labels:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
+    {{- if and .Params.SecretName .Params.SecretPath }}
+    secrets:
+    - name: {{ .Params.SecretName }}
+      path: {{ .Params.SecretPath }}
+      secretType: Opaque
+    {{- else if and .Params.SecretName .Params.SecretKey }}
+    envSecretKeyRefs:
+      SECRET_ENV:
+        name: {{ .Params.SecretName }}
+        key: {{ .Params.SecretKey }}
+    {{- end }}

--- a/tests/utils/job.go
+++ b/tests/utils/job.go
@@ -2,8 +2,9 @@ package utils
 
 import (
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type SparkJob struct {
@@ -41,12 +42,12 @@ func (spark *SparkOperatorInstallation) SubmitJob(job *SparkJob) error {
 }
 
 func (spark *SparkOperatorInstallation) DriverLog(job SparkJob) (string, error) {
-	driverPodName := driverPodName(job.Name)
+	driverPodName := DriverPodName(job.Name)
 	return getPodLog(spark.K8sClients, job.Namespace, driverPodName, 0)
 }
 
 func (spark *SparkOperatorInstallation) DriverLogContains(job SparkJob, text string) (bool, error) {
-	driverPodName := driverPodName(job.Name)
+	driverPodName := DriverPodName(job.Name)
 	return podLogContains(spark.K8sClients, job.Namespace, driverPodName, text)
 }
 
@@ -67,16 +68,16 @@ func (spark *SparkOperatorInstallation) WaitForOutput(job SparkJob, text string)
 
 	if err != nil {
 		log.Errorf("The text '%s' haven't appeared in the log in %s", text, defaultRetryTimeout.String())
-		logPodLogTail(spark.K8sClients, job.Namespace, driverPodName(job.Name), 10)
+		logPodLogTail(spark.K8sClients, job.Namespace, DriverPodName(job.Name), 10)
 	}
 	return err
 }
 
 func (spark *SparkOperatorInstallation) WaitUntilSucceeded(job SparkJob) error {
-	driverPodName := driverPodName(job.Name)
+	driverPodName := DriverPodName(job.Name)
 	return waitForPodStatusPhase(spark.K8sClients, driverPodName, job.Namespace, "Succeeded")
 }
 
-func driverPodName(jobName string) string {
+func DriverPodName(jobName string) string {
 	return jobName + "-driver"
 }

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -5,15 +5,16 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"os/exec"
-	"strings"
 )
 
 /* client-go util methods */
@@ -75,6 +76,19 @@ func CreateServiceAccount(clientSet *kubernetes.Clientset, name string, namespac
 		},
 	}
 	_, err := clientSet.CoreV1().ServiceAccounts(namespace).Create(&sa)
+	return err
+}
+
+func CreateSecret(clientSet *kubernetes.Clientset, name string, namespace string, secretData map[string]string) error {
+	log.Infof("Creating a secret %s/%s with Secret Data: %q", namespace, name, secretData)
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		StringData: secretData,
+	}
+
+	_, err := clientSet.CoreV1().Secrets(namespace).Create(&secret)
 	return err
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60858](https://jira.mesosphere.com/browse/DCOS-60858)

Implements integration tests for environment based secret as well as file based secret. It creates a secret and for the case of file based test, it mounts secret as file and check mounted path in job description. For the case of env based test, it set an environment variable by referencing it to a secret key and check for the environment variable in job description.

### Why are the changes needed?
To verify File based as well as env based secret working.

### How were the changes tested?
Ran `make test` locally.
