### PR TITLE
Fix mutating admission webhook

### DIFF
--- a/kudo-operator/operator/operator.yaml
+++ b/kudo-operator/operator/operator.yaml
@@ -21,8 +21,8 @@ tasks:
         - spark-rbac.yaml
         - spark-serviceaccount.yaml
         - webhook-init-job.yaml
-        - spark-operator-deployment.yaml
         - webhook-service.yaml
+        - spark-operator-deployment.yaml
         - spark-history-server-deployment.yaml
         - spark-history-server-service.yaml
 

--- a/kudo-operator/operator/templates/spark-operator-deployment.yaml
+++ b/kudo-operator/operator/templates/spark-operator-deployment.yaml
@@ -84,6 +84,6 @@ spec:
         - -enable-webhook=true
         - -webhook-svc-namespace={{ .Namespace }}
         - -webhook-port={{ .Params.webhookPort }}
-        - -webhook-svc-name={{ .OperatorName }}-webhook
+        - -webhook-svc-name={{ .Name }}-webhook
         - -webhook-config-name={{ .OperatorName }}-webhook-config
         {{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR contains fixes for mutation admission webhook, which used to customize Spark driver and executor pods based on the specification in `SparkApplication` objects. 

After the fix is accepted and verified, it should be applied to https://github.com/kudobuilder/operators/pull/118 as well.

### Why are the changes needed?
While working on [DCOS-60865: Test pod affinity and tolerations support](https://jira.mesosphere.com/browse/DCOS-60865), it was discovered, that aforementioned features didn't work as expected, even though webhook was enabled by default and service was installed. Operator's description showed the following warning:
```
➜ k describe pod test-instance-5869fb6d47-7tqw5 -n kudo-spark-operator-testing
Warning  FailedMount  66s (x3 over 68s)  kubelet, minikube  MountVolume.SetUp failed for volume "webhook-certs" : secret "spark-webhook-certs" not found
```
But `spark-webhook-certs` was actually present:
```
➜ k get secrets spark-webhook-certs -n kudo-spark-operator-testing        
NAME                  TYPE     DATA   AGE
spark-webhook-certs   Opaque   4      4m19s
```
If we look at  the `AGE` columns for each object, we can see the operator instance `test-instance-5869fb6d47-7tqw5` was created before `spark-webhook-certs` secret:

![image](https://user-images.githubusercontent.com/47157503/68760742-a16b3080-0623-11ea-806b-2187e5dd29bb.png)

Also, `-webhook-svc-name` was changed to adhere this declaration: 
https://github.com/mesosphere/kudo-spark-operator/blob/2d7765b2569e551d53ed5c14ac93c232aabc52e0/kudo-operator/operator/templates/webhook-init-job.yaml#L23

After those fixes were applied, `ownerReferences`, `affinity` and `tolerations` appeared in `Pod`'s spec and worked as expected:
```
➜  kudo-spark-operator git:(test-affinity-and-tolerations) ✗ k get pod spark-pi-driver -o yaml -n kudo-spark-operator-testing 
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2019-11-13T11:07:38Z"
  labels:
    spark-app-selector: spark-f3c0ec9c38ac469cb571a9f62cd98702
    spark-role: driver
    sparkoperator.k8s.io/app-name: spark-pi
    sparkoperator.k8s.io/launched-by-spark-operator: "true"
    sparkoperator.k8s.io/submission-id: c0143db9-ce40-4d45-a184-bc6e6ef7198f
    version: 2.4.3
  name: spark-pi-driver
  namespace: kudo-spark-operator-testing
  ownerReferences:
  - apiVersion: sparkoperator.k8s.io/v1beta2
    controller: true
    kind: SparkApplication
    name: spark-pi
    uid: e1770465-4be1-49d5-9585-1b7fcd568cb0
  resourceVersion: "252853"
  selfLink: /api/v1/namespaces/kudo-spark-operator-testing/pods/spark-pi-driver
  uid: 28a87622-bde3-4bfa-9004-7036905f34a2
spec:
  affinity:
    podAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: non_existing_key
            operator: DoesNotExist
        topologyKey: test
...
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  - effect: NoSchedule
    key: non_existing_key
    operator: Exists
```

### How were the changes tested?
Tests from this repo
Tested locally in the scope of [DCOS-60865: Test pod affinity and tolerations support](https://jira.mesosphere.com/browse/DCOS-60865)
