### PR TITLE
DCOS-60860 - Test host network support

### DIFF
--- a/tests/network_test.go
+++ b/tests/network_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/mesosphere/kudo-spark-operator/tests/utils"
+	log "github.com/sirupsen/logrus"
+	v12 "k8s.io/api/core/v1"
+	"testing"
+)
+
+/*
+	Test that `hostNetwork` in SparkApplication propagates to driver and executor pods
+*/
+func TestHostNetworkPropagation(t *testing.T) {
+	spark := utils.SparkOperatorInstallation{}
+	err := spark.InstallSparkOperator()
+	defer spark.CleanUp()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testCases = []struct {
+		driverHN   bool
+		executorHN bool
+	}{
+		{false, false},
+		{true, false},
+		{false, true},
+		{true, true},
+	}
+
+	for i, tc := range testCases {
+		log.Infof("Running test case:\n- driver host network:\t\t%v\n- executor host network:\t%v", tc.driverHN, tc.executorHN)
+		jobName := fmt.Sprintf("host-network-test-job-%d", i)
+		job := utils.SparkJob{
+			Name:     jobName,
+			Template: "spark-mock-task-runner-job-host-network.yaml",
+			Params: map[string]interface{}{
+				"args":                []string{"1", "600"},
+				"driverHostNetwork":   tc.driverHN,
+				"executorHostNetwork": tc.executorHN,
+			},
+		}
+
+		expectedExecutorCount := 1
+
+		// Submit the job and wait for it to start
+		err = spark.SubmitJob(&job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = spark.WaitForJobState(job, v1beta2.RunningState)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait for correct number of executors to show up
+		err = utils.Retry(func() error {
+			executors, err := spark.GetExecutorState(job)
+			if err != nil {
+				return err
+			} else if len(executors) != expectedExecutorCount {
+				return errors.New(fmt.Sprintf("The number of executors is %d, but %d is expected", len(executors), expectedExecutorCount))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Verify driver pod hostNetwork and dnsPolicy values
+		driver, err := spark.DriverPod(job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		log.Infof("Driver spec.hostNetwork: %v", driver.Spec.HostNetwork)
+		log.Infof("Driver spec.dnspolicy: %v", driver.Spec.DNSPolicy)
+		if driver.Spec.HostNetwork != tc.driverHN {
+			t.Fatal(fmt.Sprintf("Unexpected hostNetwork value for driver %v: %s. Should be %v", driver.Spec.HostNetwork, driver.Name, tc.driverHN))
+		} else if tc.driverHN && driver.Spec.DNSPolicy != v12.DNSClusterFirstWithHostNet {
+			t.Fatal(fmt.Sprintf("Expected driver pod DNS policy to be \"dnsClusterFirstWithHostNet\", but it's %s", driver.Spec.DNSPolicy))
+		}
+
+		// Verify executor pods hostNetwork and dnsPolicy values
+		executors, err := spark.ExecutorPods(job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, executor := range executors {
+			log.Infof("Executor %s spec.hostNetwork: %v", executor.Name, executor.Spec.HostNetwork)
+			log.Infof("Executor %s spec.dnsPolicy: %v", executor.Name, executor.Spec.DNSPolicy)
+			if executor.Spec.HostNetwork != tc.executorHN {
+				t.Fatal(fmt.Sprintf("Unexpected hostNetwork value for driver %v: %s. Should be %v", executor.Spec.HostNetwork, executor.Name, tc.executorHN))
+			} else if tc.executorHN && executor.Spec.DNSPolicy != v12.DNSClusterFirstWithHostNet {
+				t.Fatal(fmt.Sprintf("Expected executor pod DNS policy to be \"dnsClusterFirstWithHostNet\", but it's %s", executor.Spec.DNSPolicy))
+			}
+		}
+
+		// Terminate the job while it's running
+		spark.DeleteJob(job)
+	}
+}

--- a/tests/templates/spark-linear-regression-history-server-job.yaml
+++ b/tests/templates/spark-linear-regression-history-server-job.yaml
@@ -46,7 +46,7 @@ spec:
     serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
-    instances: 1
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}

--- a/tests/templates/spark-linear-regression-job.yaml
+++ b/tests/templates/spark-linear-regression-job.yaml
@@ -35,7 +35,7 @@ spec:
     serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
-    instances: 1
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}

--- a/tests/templates/spark-mock-task-runner-job-host-network.yaml
+++ b/tests/templates/spark-mock-task-runner-job-host-network.yaml
@@ -28,7 +28,7 @@ spec:
     serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
-    instances: 1
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     hostNetwork: {{ index .Params "executorHostNetwork" }}
     labels:

--- a/tests/templates/spark-mock-task-runner-job-host-network.yaml
+++ b/tests/templates/spark-mock-task-runner-job-host-network.yaml
@@ -1,0 +1,36 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  type: Scala
+  mode: cluster
+  image: {{ .Image }}
+  imagePullPolicy: Always
+  mainClass: MockTaskRunner
+  mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
+  arguments: {{ range $i, $arg := index .Params "args" }}
+  - "{{ $arg }}"{{ end }}
+  sparkConf:
+    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
+    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
+  sparkVersion: {{ .SparkVersion }}
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    memory: "512m"
+    hostNetwork: {{ index .Params "driverHostNetwork" }}
+    labels:
+      version: {{ .SparkVersion }}
+      metrics-exposed: "true"
+    serviceAccount: {{ .ServiceAccount }}
+  executor:
+    cores: 1
+    instances: 1
+    memory: "512m"
+    hostNetwork: {{ index .Params "executorHostNetwork" }}
+    labels:
+      version: {{ .SparkVersion }}
+      metrics-exposed: "true"

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -38,7 +38,7 @@ spec:
     {{- end }}
   executor:
     cores: 1
-    instances: 1
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}

--- a/tests/templates/spark-pi.yaml
+++ b/tests/templates/spark-pi.yaml
@@ -24,7 +24,7 @@ spec:
     serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
-    instances: 1
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}

--- a/tests/templates/spark-shuffle-job.yaml
+++ b/tests/templates/spark-shuffle-job.yaml
@@ -27,7 +27,7 @@ spec:
     serviceAccount: {{ .ServiceAccount }}
   executor:
     cores: 1
-    instances: {{ index .Params "executor_count" }}
+    instances: {{ .ExecutorsCount }}
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60860](https://jira.mesosphere.com/browse/DCOS-60860)
- Adds a test for SparkApplication `spec.hostNetwork` parameter behavior according to the [user guide](https://github.com/mesosphere/spark-on-k8s-operator/blob/master/docs/user-guide.md#host-network)

Please note, that this PR temporarily includes changes from #60 as well, to prevent CI builds from failing. Once #60 is merged I'll rebase this PR to make the diff cleaner.

### How were the changes tested?
With `make test` in a k8s cluster in AWS.
