### PR TITLE
Switching to 'local' scheme in tests based on Spark examples jar

### DIFF
--- a/tests/templates/spark-linear-regression-history-server-job.yaml
+++ b/tests/templates/spark-linear-regression-history-server-job.yaml
@@ -34,7 +34,7 @@ spec:
     {{- end }}
   deps:
     jars:
-      - http://central.maven.org/maven2/com/github/scopt/scopt_2.11/3.7.0/scopt_2.11-3.7.0.jar
+      - local:///opt/spark/examples/jars/scopt_2.11-3.7.0.jar
   sparkVersion: {{ .SparkVersion }}
   restartPolicy:
     type: Never

--- a/tests/templates/spark-linear-regression-job.yaml
+++ b/tests/templates/spark-linear-regression-job.yaml
@@ -23,7 +23,7 @@ spec:
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
   deps:
     jars:
-      - http://central.maven.org/maven2/com/github/scopt/scopt_2.11/3.7.0/scopt_2.11-3.7.0.jar
+      - local:///opt/spark/examples/jars/scopt_2.11-3.7.0.jar
   sparkVersion: {{ .SparkVersion }}
   restartPolicy:
     type: Never


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60993: Master builds fail for tests based on linear regression](https://jira.mesosphere.com/browse/DCOS-60993).
This PR changes the dependency jar URI scheme from remote(`http`) to `local` for `scopt` library which is needed for linear regression application used in tests.

### Why are the changes needed?
Two of KUDO Spark CI tests started constantly failing for PRs in all branches and on `master`. Failed tests rely on linear regression example application which requires `scopt` option parsing library as a dependency but fails to fetch it.

After verifying that the fetching mechanism works as expected by providing a different location of the same library, it turned out that the issue was in the remote jar file corruption of one form or another. The solution for this specific issue would be switching to `local` scheme for this dependency jar to avoid this kind of problems in the future. This will also make tests more focused on their main objectives and prevent from side-effects not related or caused by functionality under test.

### How were the changes tested?
- manually on a private cluster
- integration tests from this repo