### PR TITLE
[DCOS-60866] Test pod security context

### DIFF
--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -11,6 +11,7 @@ RUN set -ex && \
     ln -s /lib /lib64 && \
     apk add --no-cache bash tini libc6-compat linux-pam nss gnupg procps && \
     mkdir -p ${SPARK_HOME}/work-dir && \
+    chmod ugo+rw ${SPARK_HOME}/work-dir && \
     touch ${SPARK_HOME}/RELEASE && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
@@ -31,8 +32,8 @@ RUN mkdir -p ${SPARK_DIST} && \
 WORKDIR ${SPARK_HOME}
 
 # https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/591
-RUN rm jars/kubernetes-client-4.1.2.jar
 ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar jars
+RUN rm jars/kubernetes-client-4.1.2.jar && chmod go+r jars/kubernetes-client-4.4.2.jar
 
 # Setup for the Prometheus JMX exporter.
 RUN mkdir -p /etc/metrics/conf

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"errors"
 	"fmt"
+	"gotest.tools/assert"
 	"strings"
 	"testing"
 
@@ -381,4 +382,40 @@ func runSecretTest(secretName string, secretPath string, secretKey string, expec
 	}
 
 	return nil
+}
+
+func TestPodSecurityContext(t *testing.T) {
+
+	// run driver and executor as user "nobody"
+	const uid = "65534"
+	const gid = "65534"
+
+	spark := utils.SparkOperatorInstallation{}
+	err := spark.InstallSparkOperator()
+	defer spark.CleanUp()
+
+	assert.NilError(t, err)
+
+	jobName := "mock-task-runner"
+	job := utils.SparkJob{
+		Name:     jobName,
+		Template: "spark-mock-task-runner-job.yaml",
+		Params: map[string]interface{}{
+			"args":       []string{"1", "10"},
+			"RunAsUser":  uid,
+			"RunAsGroup": gid,
+		},
+	}
+
+	err = spark.SubmitJob(&job)
+	assert.NilError(t, err)
+
+	// verify job completed successfully
+	err = spark.WaitUntilSucceeded(job)
+	assert.NilError(t, err)
+
+	// verify uid propagated to the pod
+	logContains, err := spark.DriverLogContains(job, fmt.Sprintf("myuid=%s", uid))
+	assert.NilError(t, err)
+	assert.Assert(t, logContains, "uid \"%s\" not found in log.")
 }

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -36,6 +36,12 @@ spec:
         name: {{ .Params.SecretName }}
         key: {{ .Params.SecretKey }}
     {{- end }}
+    {{- if and .Params.RunAsUser .Params.RunAsGroup }}
+    securityContext:
+      runAsUser: {{ .Params.RunAsUser }}
+      runAsGroup: {{ .Params.RunAsGroup }}
+      runAsNonRoot: true
+    {{- end }}
   executor:
     cores: 1
     instances: {{ .ExecutorsCount }}
@@ -53,4 +59,10 @@ spec:
       SECRET_ENV:
         name: {{ .Params.SecretName }}
         key: {{ .Params.SecretKey }}
+    {{- end }}
+    {{- if and .Params.RunAsUser .Params.RunAsGroup }}
+    securityContext:
+      runAsUser: {{ .Params.RunAsUser }}
+      runAsGroup: {{ .Params.RunAsGroup }}
+      runAsNonRoot: true
     {{- end }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60866: Test pod security context](https://jira.mesosphere.com/browse/DCOS-60866)

This PR introduces a test for pod security context as well as a few fixes in Spark base image Dockerfile, which allow running Spark jobs as a non-root user.

### Why are the changes needed?
Due to insufficient permissions, Spark application failed with errors when running as a `nobody` user.
Pod spec:
```
securityContext:
      runAsUser: 65534
      runAsGroup: 65534
      runAsNonRoot: true
```
Exception in Driver's log:
```
Exception in thread "main" java.lang.NoClassDefFoundError: io/fabric8/kubernetes/client/KubernetesClient
```
```bash
bash-4.4# ls -l /opt/spark/jars/ | grep kubernetes
-rw-------    1 root     root        616644 Aug 23 16:48 kubernetes-client-4.4.2.jar
-rw-r--r--    1 root     root       9386214 Oct 18 01:15 kubernetes-model-4.1.2.jar
-rw-r--r--    1 root     root          3817 Oct 18 01:15 kubernetes-model-common-4.1.2.jar
-rw-r--r--    1 root     root        538176 Oct 18 01:15 spark-kubernetes_2.11-2.4.3.jar
```
Also, write permissions were added for `/opt/spark/work-dir` to allow saving job-related files. 

### How were the changes tested?
- by running a test on a private cluster
- integration tests from this repo