### PR TITLE
[DCOS-60862] [Spark Operator] Test mounting volumes support

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -216,7 +216,7 @@ func TestVolumeMounts(t *testing.T) {
 		Name:     jobName,
 		Template: "spark-mock-task-runner-job.yaml",
 		Params: map[string]interface{}{
-			"args":       []string{"1", "100"},
+			"args":       []string{"1", "60"},
 			"VolumeName": volumeName,
 			"MountPath":  mountPath,
 		},

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -21,8 +21,9 @@ spec:
   {{- if .Params.VolumeName }}
   volumes:
   - name: {{ .Params.VolumeName }}
-    hostPath: "/data"
-    type: DirectoryOrCreate
+    hostPath:
+      path: /data
+      type: DirectoryOrCreate
   {{- end }}
   driver:
     cores: 1

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -18,6 +18,12 @@ spec:
   sparkVersion: {{ .SparkVersion }}
   restartPolicy:
     type: Never
+  {{- if .Params.VolumeName }}
+  volumes:
+  - name: {{ .Params.VolumeName }}
+    hostPath: "/data"
+    type: DirectoryOrCreate
+  {{- end }}
   driver:
     cores: 1
     memory: "512m"
@@ -25,6 +31,11 @@ spec:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
     serviceAccount: {{ .ServiceAccount }}
+    {{- if .Params.VolumeName }}
+    volumeMounts:
+    - name: {{ .Params.VolumeName }}
+      mountPath: {{ .Params.MountPath }}
+    {{- end }}
     {{- if and .Params.SecretName .Params.SecretPath }}
     secrets:
     - name: {{ .Params.SecretName }}
@@ -43,6 +54,11 @@ spec:
     labels:
       version: {{ .SparkVersion }}
       metrics-exposed: "true"
+    {{- if .Params.VolumeName }}
+    volumeMounts:
+    - name: {{ .Params.VolumeName }}
+      mountPath: {{ .Params.MountPath }}
+    {{- end }}
     {{- if and .Params.SecretName .Params.SecretPath }}
     secrets:
     - name: {{ .Params.SecretName }}

--- a/tests/templates/spark-mock-task-runner-job.yaml
+++ b/tests/templates/spark-mock-task-runner-job.yaml
@@ -15,6 +15,9 @@ spec:
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
+    {{- if .Params.VolumeName }}
+    "spark.local.dir": "{{ .Params.MountPath }}/tmp"
+    {{- end }}
   sparkVersion: {{ .SparkVersion }}
   restartPolicy:
     type: Never


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-60862](https://jira.mesosphere.com/browse/DCOS-60862)

Implements integration tests for mounting volumes support. It uses `hostPath` type of volume for this test. Create a file and check for its existence to verify the volume is writable or not.

### Why are the changes needed?
To verify volume mounting support

### How were the changes tested?
Ran `make test` locally.
