### PR TITLE
[DCOS-61247] Provide Python support

### DIFF
--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -3,21 +3,26 @@ FROM openjdk:8-alpine
 ARG SPARK_HOME=/opt/spark
 ARG SPARK_DIST=/dist
 ENV SPARK_HOME ${SPARK_HOME}
+ENV PYTHONPATH ${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-*.zip
 ARG SPARK_DIST_NAME="spark-2.4.3-hadoop-2.9-k8s"
 ARG SPARK_DIST_URL="https://downloads.mesosphere.io/spark/assets/${SPARK_DIST_NAME}.tgz"
 
 RUN set -ex && \
     apk upgrade --no-cache && \
     ln -s /lib /lib64 && \
-    apk add --no-cache bash tini libc6-compat linux-pam nss gnupg procps && \
-    mkdir -p ${SPARK_HOME}/work-dir && \
+    apk add --no-cache bash tini libc6-compat linux-pam nss gnupg procps python python3 && \
+    mkdir -p ${SPARK_HOME}/work-dir ${SPARK_HOME}/python && \
     chmod ugo+rw ${SPARK_HOME}/work-dir && \
     touch ${SPARK_HOME}/RELEASE && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd && \
-    rm -rf /var/cache/apk/*
+    python -m ensurepip && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip install --upgrade pip setuptools && \
+    rm -rf /var/cache/apk/* /root/.cache
 
 RUN mkdir -p ${SPARK_DIST} && \
     cd ${SPARK_DIST} && \
@@ -25,6 +30,7 @@ RUN mkdir -p ${SPARK_DIST} && \
     gpg --print-md sha512 ${SPARK_DIST_NAME}.tgz | diff - ${SPARK_DIST_NAME}.tgz.sha512 && \
     tar xf ${SPARK_DIST_NAME}.tgz -C ${SPARK_DIST} --strip-components=1 && \
     mv jars bin sbin data examples ${SPARK_HOME} && \
+    mv python/lib ${SPARK_HOME}/python/lib && \
     mv kubernetes/dockerfiles/spark/entrypoint.sh /opt && \
     mv kubernetes/tests ${SPARK_HOME} && \
     rm -rf ${SPARK_DIST}

--- a/tests/affinity_and_toleration_test.go
+++ b/tests/affinity_and_toleration_test.go
@@ -64,7 +64,7 @@ func TestPodAffinityAndToleration(t *testing.T) {
 	t.Run("TestDriverPod", func(t *testing.T) {
 		driver, err := spark.DriverPod(job)
 		assert.NilError(t, err)
-		verifyPodSpec(t, *driver)
+		verifyPodSpec(t, driver)
 	})
 
 	t.Run("TestExecutorPod", func(t *testing.T) {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -258,3 +258,25 @@ func TestVolumeMounts(t *testing.T) {
 		t.Error(err.Error())
 	}
 }
+
+func TestPythonSupport(t *testing.T) {
+	spark := utils.SparkOperatorInstallation{}
+	if err := spark.InstallSparkOperator(); err != nil {
+		t.Fatal(err)
+	}
+	defer spark.CleanUp()
+
+	jobName := "spark-pi-python"
+	job := utils.SparkJob{
+		Name:     jobName,
+		Template: fmt.Sprintf("%s.yaml", jobName),
+	}
+
+	if err := spark.SubmitJob(&job); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := spark.WaitForOutput(job, "Pi is roughly 3.14"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -433,7 +433,7 @@ func TestPodSecurityContext(t *testing.T) {
 			fmt.Sprintf("gids don't match! %d != %d", *securityContext.RunAsGroup, gidInt))
 	}
 
-	verifyPodSecurityContext(*driver)
+	verifyPodSecurityContext(driver)
 	verifyPodSecurityContext(executorPods[0])
 
 	err = spark.WaitUntilSucceeded(job)

--- a/tests/templates/spark-pi-python.yaml
+++ b/tests/templates/spark-pi-python.yaml
@@ -1,0 +1,29 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  type: Python
+  mode: cluster
+  image: {{ .Image }}
+  imagePullPolicy: Always
+  mainApplicationFile: "local:///opt/spark/examples/src/main/python/pi.py"
+  sparkConf:
+    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
+    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
+  sparkVersion: {{ .SparkVersion }}
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    memory: "512m"
+    labels:
+      version: {{ .SparkVersion }}
+    serviceAccount: {{ .ServiceAccount }}
+  executor:
+    cores: 1
+    instances: {{ .ExecutorsCount }}
+    memory: "512m"
+    labels:
+      version: {{ .SparkVersion }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-61247](https://jira.mesosphere.com/browse/DCOS-61247)
This PR adds Python support to the base Spark docker image. Also, a simple test was added to the test suite to verify python-based applications work correctly.

### Why are the changes needed?
To add Python support as well as required libraries to base Spark docker image.

### How were the changes tested?
by running the new test locally
by running integration test suite in the CI
by verifying environment setup inside a container via `docker run`:
```
bash-4.4# python --version
Python 2.7.16
bash-4.4# python3 --version
Python 3.6.9
```
pyspark example:
```
bash-4.4# /opt/spark/bin/pyspark 
>>> import pyspark
>>> sc = pyspark.SparkContext('local[*]')
19/12/06 13:12:38 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
>>> rdd = sc.parallelize(range(100),2)
>>> even = rdd.filter(lambda x: x % 2 ==0)
>>> even.take(10)
[0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
```