### PR TITLE
[DCOS-61620] Provide and test SparkR support

### DIFF
--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -4,14 +4,15 @@ ARG SPARK_HOME=/opt/spark
 ARG SPARK_DIST=/dist
 ENV SPARK_HOME ${SPARK_HOME}
 ENV PYTHONPATH ${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py4j-*.zip
+ENV R_HOME /usr/lib/R
 ARG SPARK_DIST_NAME="spark-2.4.3-hadoop-2.9-k8s"
 ARG SPARK_DIST_URL="https://downloads.mesosphere.io/spark/assets/${SPARK_DIST_NAME}.tgz"
 
 RUN set -ex && \
     apk upgrade --no-cache && \
     ln -s /lib /lib64 && \
-    apk add --no-cache bash tini libc6-compat linux-pam nss gnupg procps python python3 && \
-    mkdir -p ${SPARK_HOME}/work-dir ${SPARK_HOME}/python && \
+    apk add --no-cache bash tini libc6-compat linux-pam nss gnupg procps python python3 R R-dev && \
+    mkdir -p ${SPARK_HOME}/work-dir ${SPARK_HOME}/python ${SPARK_HOME}/R && \
     chmod ugo+rw ${SPARK_HOME}/work-dir && \
     touch ${SPARK_HOME}/RELEASE && \
     rm /bin/sh && \
@@ -29,7 +30,7 @@ RUN mkdir -p ${SPARK_DIST} && \
     wget ${SPARK_DIST_URL} && wget ${SPARK_DIST_URL}.sha512 && \
     gpg --print-md sha512 ${SPARK_DIST_NAME}.tgz | diff - ${SPARK_DIST_NAME}.tgz.sha512 && \
     tar xf ${SPARK_DIST_NAME}.tgz -C ${SPARK_DIST} --strip-components=1 && \
-    mv jars bin sbin data examples ${SPARK_HOME} && \
+    mv jars bin sbin data examples R ${SPARK_HOME} && \
     mv python/lib ${SPARK_HOME}/python/lib && \
     mv kubernetes/dockerfiles/spark/entrypoint.sh /opt && \
     mv kubernetes/tests ${SPARK_HOME} && \

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -280,3 +280,30 @@ func TestPythonSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestRSupport(t *testing.T) {
+	spark := utils.SparkOperatorInstallation{}
+	if err := spark.InstallSparkOperator(); err != nil {
+		t.Fatal(err)
+	}
+	defer spark.CleanUp()
+
+	jobName := "spark-r-als"
+	job := utils.SparkJob{
+		Name:           jobName,
+		Template:       fmt.Sprintf("%s.yaml", jobName),
+		ExecutorsCount: 3,
+	}
+
+	if err := spark.SubmitJob(&job); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := spark.WaitForOutput(job, "3   2.997274"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := spark.WaitUntilSucceeded(job); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tests/templates/spark-r-als.yaml
+++ b/tests/templates/spark-r-als.yaml
@@ -1,0 +1,29 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+spec:
+  type: R
+  mode: cluster
+  image: {{ .Image }}
+  imagePullPolicy: Always
+  mainApplicationFile: "local:///opt/spark/examples/src/main/r/ml/als.R"
+  sparkConf:
+    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
+    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
+  sparkVersion: {{ .SparkVersion }}
+  restartPolicy:
+    type: Never
+  driver:
+    cores: 1
+    memory: "512m"
+    labels:
+      version: {{ .SparkVersion }}
+    serviceAccount: {{ .ServiceAccount }}
+  executor:
+    cores: 1
+    instances: {{ .ExecutorsCount }}
+    memory: "512m"
+    labels:
+      version: {{ .SparkVersion }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-61620](https://jira.mesosphere.com/browse/DCOS-61620)
This PR adds SparkR support to base Spark image as well as an integration test for exercising R API.  

### Why are the changes needed? 
Add the ability to run SparkR applications on Kudo Spark Operator by updating the base Spark image. 
Also, an integration test was added to the test suite. The test submits SparkR application, which makes a prediction based on Alternating Least Squares algorithm. 

### How were the changes tested?
By running the test locally on minikube;
By running tests from this repo in CI.