### PR TITLE
Fix flaky test

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -276,7 +276,7 @@ func TestPythonSupport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := spark.WaitForOutput(job, "Pi is roughly 3.14"); err != nil {
+	if err := spark.WaitForOutput(job, "Pi is roughly 3.1"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/utils/job.go
+++ b/tests/utils/job.go
@@ -118,7 +118,7 @@ func (spark *SparkOperatorInstallation) WaitForOutput(job SparkJob, text string)
 
 	if err != nil {
 		log.Errorf("The text '%s' haven't appeared in the log in %s", text, defaultRetryTimeout.String())
-		logPodLogTail(spark.K8sClients, job.Namespace, DriverPodName(job.Name), 10)
+		logPodLogTail(spark.K8sClients, job.Namespace, DriverPodName(job.Name), 0) // 0 - print logs since pod's creation
 	}
 	return err
 }

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -143,7 +143,7 @@ func podLogContains(clientSet *kubernetes.Clientset, namespace string, pod strin
 func logPodLogTail(clientSet *kubernetes.Clientset, namespace string, pod string, lines int64) error {
 	logTail, err := getPodLog(clientSet, namespace, pod, lines)
 	if err == nil {
-		log.Infof("Last %d lines of %s log:\n%s", lines, pod, logTail)
+		log.Infof("pod logs:\n%s", logTail)
 	}
 	return err
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR contains a fix for flaky test:
https://teamcity.mesosphere.io/project.html?projectId=Frameworks_DataServices_Kudo_Spark_Pr&testNameId=2269851367190235341&tab=testDetails

### Why are the changes needed?
One of the tests is flaky due to a slight deviation of Pi calculation, produced by Spark job:
```
19/12/11 13:03:23 INFO DAGScheduler: Job 0 finished: reduce at /opt/spark/examples/src/main/python/pi.py:44, took 3.725619 s
Pi is roughly 3.133980
```

### How were the changes tested?
tests from this repo
