### PR TITLE
[DCOS-61883] Refactor release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,3 @@ define tag_and_push_image
 		echo "Error: image \"$(RELEASE_IMAGE_FULL_NAME)\" already exists, will not proceed with overwrite."; false
 	fi
 endef
-
-
-

--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,14 @@ test:
 install:
 	OPERATOR_DOCKER_REPO=$(OPERATOR_DOCKER_REPO) OPERATOR_VERSION=$(OPERATOR_VERSION) $(SCRIPTS_DIR)/install_operator.sh
 
-.PHONY: release
-release: docker-spark
-release: docker-operator
-release:
+.PHONY: release-spark
+release-spark: docker-spark
+release-spark:
 	$(call tag_and_push_image,$(SPARK_RELEASE_DOCKER_REPO),$(SPARK_IMAGE_RELEASE_TAG),$(SPARK_IMAGE_FULL_NAME))
+
+.PHONY: release-operator
+release-operator: docker-operator
+release-operator:
 	$(call tag_and_push_image,$(OPERATOR_RELEASE_DOCKER_REPO),$(OPERATOR_IMAGE_RELEASE_TAG),$(OPERATOR_IMAGE_FULL_NAME))
 
 .PHONY: clean-docker
@@ -185,13 +188,12 @@ define tag_and_push_image
 	$(eval RELEASE_IMAGE_FULL_NAME=$(1):$(2))
 	# check, if specified image already exists to prevent overwrites
 	if [[ -z "$(call remote_image_exists,$(1),$(2))" ]]; then
-		# check, if dev image is present in local docker registry
-		[[ -z "$(call local_image_exists,$(3))" ]] && docker pull $(3)
+		docker pull $(3)
 		docker tag $(3) $(RELEASE_IMAGE_FULL_NAME)
 		echo "Pushing image \"$(RELEASE_IMAGE_FULL_NAME)\""
 		docker push $(RELEASE_IMAGE_FULL_NAME)
 	else
-		echo "Warning: image \"$(RELEASE_IMAGE_FULL_NAME)\" already exists, skipping overwrite."
+		echo "Error: image \"$(RELEASE_IMAGE_FULL_NAME)\" already exists, will not proceed with overwrite."; false
 	fi
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -138,23 +138,8 @@ install:
 release: docker-spark
 release: docker-operator
 release:
-	$(eval SPARK_RELEASE_IMAGE_FULL_NAME=$(SPARK_RELEASE_DOCKER_REPO):$(SPARK_IMAGE_RELEASE_TAG))
-	$(eval OPERATOR_RELEASE_IMAGE_FULL_NAME=$(OPERATOR_RELEASE_DOCKER_REPO):$(OPERATOR_IMAGE_RELEASE_TAG))
-
-	if [[ -z "$(call remote_image_exists,$(SPARK_RELEASE_DOCKER_REPO),$(SPARK_IMAGE_RELEASE_TAG))" ]]; then
-		docker tag $(SPARK_IMAGE_FULL_NAME) $(SPARK_RELEASE_IMAGE_FULL_NAME)
-		echo "Pushing $(SPARK_RELEASE_IMAGE_FULL_NAME)"
-		docker push $(SPARK_RELEASE_IMAGE_FULL_NAME)
-	else
-		echo "Warning: image \"$(SPARK_RELEASE_IMAGE_FULL_NAME)\" already exists, skipping overwrite."
-	fi
-	if [[ -z "$(call remote_image_exists,$(OPERATOR_RELEASE_DOCKER_REPO),$(OPERATOR_IMAGE_RELEASE_TAG))" ]]; then
-		docker tag $(OPERATOR_IMAGE_FULL_NAME) $(OPERATOR_RELEASE_IMAGE_FULL_NAME)
-		echo "Pushing image \"$(OPERATOR_RELEASE_IMAGE_FULL_NAME)\""
-		docker push $(OPERATOR_RELEASE_IMAGE_FULL_NAME)
-	else
-		echo "Warning: image \"$(OPERATOR_RELEASE_IMAGE_FULL_NAME)\" already exists, skipping overwrite."
-	fi
+	$(call tag_and_push_image,$(SPARK_RELEASE_DOCKER_REPO),$(SPARK_IMAGE_RELEASE_TAG),$(SPARK_IMAGE_FULL_NAME))
+	$(call tag_and_push_image,$(OPERATOR_RELEASE_DOCKER_REPO),$(OPERATOR_IMAGE_RELEASE_TAG),$(OPERATOR_IMAGE_FULL_NAME))
 
 .PHONY: clean-docker
 clean-docker:
@@ -191,3 +176,24 @@ endef
 define local_image_exists
 $(shell docker images -q $1 2> /dev/null)
 endef
+
+# arguments:
+# $1 - release image repo, e.g. mesosphere/spark
+# $2 - release image tag, e.g spark-2.4.3-hadoop-2.9-k8s
+# $3 - dev image full name, e.g mesosphere/spark-dev:ab36f1f3691a8be2050f3acb559c34e3e8e5d66e
+define tag_and_push_image
+	$(eval RELEASE_IMAGE_FULL_NAME=$(1):$(2))
+	# check, if specified image already exists to prevent overwrites
+	if [[ -z "$(call remote_image_exists,$(1),$(2))" ]]; then
+		# check, if dev image is present in local docker registry
+		[[ -z "$(call local_image_exists,$(3))" ]] && docker pull $(3)
+		docker tag $(3) $(RELEASE_IMAGE_FULL_NAME)
+		echo "Pushing image \"$(RELEASE_IMAGE_FULL_NAME)\""
+		docker push $(RELEASE_IMAGE_FULL_NAME)
+	else
+		echo "Warning: image \"$(RELEASE_IMAGE_FULL_NAME)\" already exists, skipping overwrite."
+	fi
+endef
+
+
+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-61883: Create a TC job for Spark operator release](https://jira.mesosphere.com/browse/DCOS-61883)
Changes:
- added a fix for the case, when `*-dev` images are not present on a build agent;
- code refactoring

### Why are the changes needed?
To improve release job stability and improve code clarity.

### How were the changes tested?
- by executing `make release` locally (without pushing the images);
- by running a release job in TC: https://teamcity.mesosphere.io/viewLog.html?buildId=2488660&buildTypeId=Frameworks_DataServices_Kudo_Spark_Tools_Release&tab=buildResultsDiv
- by verifying image digests:
https://hub.docker.com/layers/mesosphere/spark/operator-test-release/images/sha256-63cc42f1b880bb806949bb08187c628c6e5d8ace4a100e0cc064f8af849b57eb
https://hub.docker.com/layers/mesosphere/spark-dev/ab36f1f3691a8be2050f3acb559c34e3e8e5d66e/images/sha256-63cc42f1b880bb806949bb08187c628c6e5d8ace4a100e0cc064f8af849b57eb
--
https://hub.docker.com/layers/mesosphere/kudo-spark-operator/operator-test-release/images/sha256-48b1c44f9e423e0ad554130402a2264ac7b3637777b731bdfdd1488b63c7f91f
https://hub.docker.com/layers/mesosphere/kudo-spark-operator-dev/f113cf2a98ee13836517473e71420fe427b6ff9f/images/sha256-48b1c44f9e423e0ad554130402a2264ac7b3637777b731bdfdd1488b63c7f91f