### PR TITLE
[DCOS-62592] Fix TestSparkHistoryServerInstallation test

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -161,9 +161,10 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	historyServerPodName, err := utils.Kubectl(
 		"get",
 		"pods",
-		"--namespace="+spark.Namespace,
-		"--output=jsonpath={.items[?(@.metadata.labels.app\\.kubernetes\\.io/name==\""+instanceName+"\")].metadata.name}",
-	)
+		fmt.Sprintf("--namespace=%s", spark.Namespace),
+		"--field-selector=status.phase=Running",
+		fmt.Sprintf("--selector=app.kubernetes.io/name=%s", instanceName),
+		"--output=jsonpath={.items[*].metadata.name}")
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -203,6 +204,8 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("The Job Id '%s' haven't appeared in History Server", jobID)
+		log.Infof("Spark History Server logs:")
+		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
 	}
 	utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [DCOS-62592: TestSparkHistoryServerInstallation test is flaky](https://jira.mesosphere.com/browse/DCOS-62592)
- introduce additional filter to prevent multiple pods in results;
- add SHS pod logs output for troubleshooting in case of errors

### Why are the changes needed?
to eliminate flakes from tests suite

### How were the changes tested?
tests from this repo
