### PR TITLE
Fix for S3 folder removal in Spark History test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export AWS_SECRET_ACCESS_KEY ?=
 export AWS_SESSION_TOKEN ?=
 
 AWS_BUCKET_NAME ?= "kudo-ds-ci-artifacts"
-AWS_BUCKET_PATH ?= "autodelete7d/spark-operator-history-server-test"
+AWS_BUCKET_PATH ?= "kudo-spark-operator/tests/spark-history-server"
 
 .PHONY: aws_credentials
 aws_credentials:

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -2,14 +2,12 @@ package tests
 
 import (
 	"fmt"
-	"os"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/mesosphere/kudo-spark-operator/tests/utils"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"strings"
+	"testing"
 )
 
 func TestMain(m *testing.M) {
@@ -96,13 +94,8 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		t.Fatal("AWS_BUCKET_PATH is not configured")
 	}
 
-	// Make sure folder is deleted
-	err := utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
 	// Make sure folder is created
-	err = utils.AwsS3CreateFolder(awsBucketName, awsFolderPath)
+	err := utils.AwsS3CreateFolder(awsBucketName, awsFolderPath)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -181,7 +174,7 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	}
 
 	// Get an application detail from History Server
-	err = utils.RetryWithTimeout(2*time.Minute, 5*time.Second, func() error {
+	err = utils.RetryWithTimeout(utils.DefaultRetryTimeout, utils.DefaultRetryInterval, func() error {
 		historyServerResponse, err := utils.Kubectl(
 			"exec",
 			historyServerPodName,
@@ -207,7 +200,6 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		log.Infof("Spark History Server logs:")
 		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
 	}
-	utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 }
 
 func TestVolumeMounts(t *testing.T) {
@@ -237,7 +229,7 @@ func TestVolumeMounts(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	err = utils.RetryWithTimeout(2*time.Minute, 5*time.Second, func() error {
+	err = utils.RetryWithTimeout(utils.DefaultRetryTimeout, utils.DefaultRetryInterval, func() error {
 		lsCmdResponse, err := utils.Kubectl(
 			"exec",
 			utils.DriverPodName(jobName),

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/mesosphere/kudo-spark-operator/tests/utils"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -94,6 +95,7 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		t.Fatal("AWS_BUCKET_PATH is not configured")
 	}
 
+	awsFolderPath = fmt.Sprintf("%s/%s", awsFolderPath, uuid.New().String())
 	// Make sure folder is created
 	err := utils.AwsS3CreateFolder(awsBucketName, awsFolderPath)
 	if err != nil {
@@ -200,6 +202,8 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		log.Infof("Spark History Server logs:")
 		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
 	}
+
+	utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 }
 
 func TestVolumeMounts(t *testing.T) {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -101,6 +101,7 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	defer utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 
 	awsBucketPath := "s3a://" + awsBucketName + "/" + awsFolderPath
 
@@ -203,7 +204,6 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
 	}
 
-	utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 }
 
 func TestVolumeMounts(t *testing.T) {

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -44,6 +44,7 @@ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeq
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d h1:7XGaL1e6bYS1yIonGp9761ExpPPV1ui0SAC59Yube9k=

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -17,8 +17,8 @@ const DefaultInstanceName = "test-instance"
 const DefaultServiceAccountSuffix = "-spark-service-account"
 const rootDirName = "tests"
 const cmdLogFormat = ">%s %v\n%s"
-const defaultRetryInterval = 5 * time.Second
-const defaultRetryTimeout = 10 * time.Minute
+const DefaultRetryInterval = 5 * time.Second
+const DefaultRetryTimeout = 10 * time.Minute
 
 var OperatorImage = GetenvOr("OPERATOR_IMAGE", "mesosphere/kudo-spark-operator:spark-2.4.3-hadoop-2.9-k8s")
 var SparkImage = GetenvOr("SPARK_IMAGE", "mesosphere/spark:spark-2.4.3-hadoop-2.9-k8s")
@@ -60,7 +60,7 @@ func goUpToRootDir() string {
 }
 
 func Retry(fn func() error) error {
-	return RetryWithTimeout(defaultRetryTimeout, defaultRetryInterval, fn)
+	return RetryWithTimeout(DefaultRetryTimeout, DefaultRetryInterval, fn)
 }
 
 func RetryWithTimeout(timeout time.Duration, interval time.Duration, fn func() error) error {

--- a/tests/utils/job.go
+++ b/tests/utils/job.go
@@ -117,7 +117,7 @@ func (spark *SparkOperatorInstallation) WaitForOutput(job SparkJob, text string)
 	})
 
 	if err != nil {
-		log.Errorf("The text '%s' haven't appeared in the log in %s", text, defaultRetryTimeout.String())
+		log.Errorf("The text '%s' haven't appeared in the log in %s", text, DefaultRetryTimeout.String())
 		logPodLogTail(spark.K8sClients, job.Namespace, DriverPodName(job.Name), 0) // 0 - print logs since pod's creation
 	}
 	return err


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix SHS test failures caused by S3 folder deletion when parallel builds are running in CI

### Why are the changes needed?
Currently, an S3 folder, used as a log directory for storing Spark applications, is removed when the test starts and finishes. This approach must not be used in case when multiple builds are running in parallel in CI. When two tests are running concurrently, one could cause another one to fail due to folder clean-up (example [build log](https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=2525628&_focus=5696))

The proposed solution is to delegate the clean-up process to the S3 lifecycle management feature and remove clean-up from the test code.

Expiration for `kudo-ds-ci-artifacts/kudo-spark-operator/tests/spark-history-server/*` is set to one day.

### How were the changes tested?
test from this repo