### PR TITLE
Stabilize HA tests suite

### DIFF
--- a/tests/ha_test.go
+++ b/tests/ha_test.go
@@ -21,6 +21,7 @@ import (
 const electionRecordRetryInterval = 2 * time.Second
 const electionRecordRetryTimeout = 30 * time.Second
 const processingKeyLogRecordFormat = "Starting processing key: \"%s/%s\""
+const deploymentWaitTimeout = 1 * time.Minute
 
 type LeaderElectionParameters struct {
 	Replicas                    int
@@ -62,7 +63,8 @@ func (suite *HighAvailabilityTestSuite) SetupSuite() {
 		suite.FailNow(err.Error())
 	}
 	utils.Kubectl("wait", "deployment", "--all", "--for", "condition=available",
-		"--namespace", suite.operator.Namespace, "--timeout=60s")
+		"--namespace", suite.operator.Namespace,
+		fmt.Sprintf("--timeout=%v", deploymentWaitTimeout))
 }
 
 func (suite *HighAvailabilityTestSuite) TearDownSuite() {

--- a/tests/ha_test.go
+++ b/tests/ha_test.go
@@ -102,6 +102,7 @@ func (suite *HighAvailabilityTestSuite) TestFailover() {
 	if err != nil {
 		suite.FailNow(err.Error())
 	}
+	utils.Kubectl("get", "all", "-n", suite.operator.Namespace)
 	fmt.Println("Current leader: ", leaderElectionRecord.HolderIdentity)
 	// deploy workload
 	jobName := "mock-task-runner"
@@ -121,6 +122,7 @@ func (suite *HighAvailabilityTestSuite) TestFailover() {
 	}
 
 	// check leader started processing the application
+	utils.Kubectl("get", "all", "-n", suite.operator.Namespace)
 	logContains, err := utils.PodLogContains(mockTaskRunner.Namespace, leaderElectionRecord.HolderIdentity,
 		fmt.Sprintf(processingKeyLogRecordFormat, mockTaskRunner.Namespace, mockTaskRunner.Name))
 	if suite.NoError(err) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix flakiness in HA Test suite.

### Why are the changes needed?
`TestHASuite/TestFailover` test sometimes fails because of a missing leader pod [(example](https://teamcity.mesosphere.io/viewLog.html?buildId=2532422&tab=buildResultsDiv&buildTypeId=Frameworks_DataServices_Kudo_Spark_Pr_SparkPrKonvoyKudoV080pre2))
As it's turned out, at some point during deployment of the operator, the instance of `ReplicaSet` gets recreated (probably, the initial one has failed), causing previously deployed pods to be deleted. The following changes were introduced to stabilize to test flow:

- `kubectl wait` command was added to `SetupSuite` to explicitly check whether the deployment is in the completed state;
-  `getLeaderElectionRecord` method was updated to check the leader pod exists;
- logically reordered tests in the suite - it makes sense testing configuration and leader election before the failover scenario;
- added deployment state to test log for troubleshooting.

### How were the changes tested?
- locally on private cluster;
- tests from this repo;
