### PR TITLE
D2IQ-63474: Integration test and docs for S3 access credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export AWS_SECRET_ACCESS_KEY ?=
 export AWS_SESSION_TOKEN ?=
 
 AWS_BUCKET_NAME ?= "kudo-ds-ci-artifacts"
-AWS_BUCKET_PATH ?= "kudo-spark-operator/tests/spark-history-server"
+AWS_BUCKET_PATH ?= "kudo-spark-operator/tests"
 
 .PHONY: aws_credentials
 aws_credentials:

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -2,12 +2,11 @@
 
 set -ex
 SCRIPT_DIR=$(dirname "$0")
-SPECS_DIR="$(dirname ${SCRIPT_DIR})/specs"
 OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/operators/repository/spark/operator"
 
 NAMESPACE=${NAMESPACE:-spark}
 OPERATOR_DOCKER_REPO=${OPERATOR_DOCKER_REPO:-mesosphere/kudo-spark-operator}
-OPERATOR_VERSION=${OPERATOR_VERSION:-latest}
+OPERATOR_VERSION=${OPERATOR_VERSION:-2.4.4-0.2.0}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 
@@ -28,10 +27,4 @@ EOF
 
     kubectl kudo --namespace "${NAMESPACE}" install "${OPERATOR_DIR}" -p operatorImageName="${OPERATOR_DOCKER_REPO}" -p operatorVersion="${OPERATOR_VERSION}"
 fi
-
-kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-driver-rbac.yaml
-
-# Create Service to expose Spark Driver's and Executors metrics endpoint.
-# TODO: make the spark-application-metrics-service.yaml manageable by the kudo-spark-operator once the issue https://github.com/kudobuilder/kudo/issues/916 will be fixed.
-kubectl apply --namespace "${NAMESPACE}" -f ${SPECS_DIR}/spark-application-metrics-service.yaml
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -222,6 +222,8 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		t.Errorf("The Job Id '%s' haven't appeared in History Server", jobID)
 		log.Infof("Spark History Server logs:")
 		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
+		log.Info("Driver logs:")
+		utils.Kubectl("logs", "-n", spark.Namespace, utils.DriverPodName(job.Name))
 	}
 }
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -139,7 +139,6 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 	operatorParams := map[string]string{
 		"enableHistoryServer":          "true",
 		"historyServerFsLogDirectory":  awsBucketPath,
-		"historyServerSparkConf":       utils.DefaultAwsSecretName,
 		"historyServerOpts":            "-Dspark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem",
 		"historyServerSparkConfSecret": sparkConfSecretName,
 	}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mesosphere/kudo-spark-operator/tests/utils"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 	"strings"
 	"testing"
 )
@@ -83,80 +82,101 @@ func TestJobSubmission(t *testing.T) {
 }
 
 func TestSparkHistoryServerInstallation(t *testing.T) {
-	awsAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
-	awsAccessSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
-	awsSessionToken := os.Getenv("AWS_SESSION_TOKEN")
-	awsBucketName, present := os.LookupEnv("AWS_BUCKET_NAME")
-	if !present {
-		t.Fatal("AWS_BUCKET_NAME is not configured")
+	awsBucketName, err := utils.GetS3BucketName()
+	if err != nil {
+		t.Fatal(err)
 	}
-	awsFolderPath, present := os.LookupEnv("AWS_BUCKET_PATH")
-	if !present {
-		t.Fatal("AWS_BUCKET_PATH is not configured")
+	awsFolderPath, err := utils.GetS3BucketPath()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	awsFolderPath = fmt.Sprintf("%s/%s", awsFolderPath, uuid.New().String())
+	awsFolderPath = fmt.Sprintf("%s/%s/%s", awsFolderPath, "spark-history-server", uuid.New().String())
 	// Make sure folder is created
-	err := utils.AwsS3CreateFolder(awsBucketName, awsFolderPath)
-	if err != nil {
+	if err := utils.AwsS3CreateFolder(awsBucketName, awsFolderPath); err != nil {
 		t.Fatal(err.Error())
 	}
 	defer utils.AwsS3DeleteFolder(awsBucketName, awsFolderPath)
 
 	awsBucketPath := "s3a://" + awsBucketName + "/" + awsFolderPath
 
-	historyParams := make(map[string]string)
-	historyParams["enableHistoryServer"] = "true"
-	historyParams["historyServerFsLogDirectory"] = awsBucketPath
+	awsCredentials, err := utils.GetAwsCredentials()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	historyParams["historyServerOpts"] = "-Dspark.hadoop.fs.s3a.access.key=" + awsAccessKey +
-		" -Dspark.hadoop.fs.s3a.secret.key=" + awsAccessSecret +
-		" -Dspark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem"
+	clientSet, err := utils.GetK8sClientSet()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if len(awsSessionToken) > 0 {
-		historyParams["historyServerOpts"] = historyParams["historyServerOpts"] +
-			" -Dspark.hadoop.fs.s3a.session.token=" + awsSessionToken +
-			" -Dspark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
+	if _, err := utils.CreateNamespace(clientSet, utils.DefaultNamespace); err != nil {
+		t.Fatal(err)
+	}
+
+	// create a Secret with AWS credentials which will be used by Spark History Server and SparkApplication to authenticate with S3
+	if err := utils.CreateSecretEncoded(clientSet, utils.DefaultAwsSecretName, utils.DefaultNamespace, awsCredentials); err != nil {
+		t.Fatal("Error while creating a Secret", err)
+	}
+
+	// configure Spark Operator parameters
+	operatorParams := map[string]string{
+		"enableHistoryServer":         "true",
+		"historyServerFsLogDirectory": awsBucketPath,
+		"awsCredentialsSecretName":    utils.DefaultAwsSecretName,
+		"historyServerOpts":           "-Dspark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem",
+	}
+
+	// in case we are using temporary security credentials
+	if len(string(awsCredentials[utils.AwsSessionToken])) > 0 {
+		operatorParams["historyServerOpts"] =
+			strings.Join(
+				[]string{
+					operatorParams["historyServerOpts"],
+					"-Dspark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider",
+				},
+				" ",
+			)
+
 	}
 
 	spark := utils.SparkOperatorInstallation{
-		Params: historyParams,
+		SkipNamespaceCleanUp: true,
+		Params:               operatorParams,
 	}
-	err = spark.InstallSparkOperator()
-	defer spark.CleanUp()
 
-	if err != nil {
+	if err := spark.InstallSparkOperator(); err != nil {
 		t.Fatal(err.Error())
 	}
+	defer spark.CleanUp()
 
-	awsParams := map[string]interface{}{
-		"AwsBucketPath":   awsBucketPath,
-		"AwsAccessKey":    awsAccessKey,
-		"AwsAccessSecret": awsAccessSecret,
-		"AwsSessionToken": awsSessionToken,
+	sparkAppParams := map[string]interface{}{
+		"AwsBucketPath": awsBucketPath,
+		"AwsSecretName": utils.DefaultAwsSecretName,
 	}
+
+	if _, isPresent := awsCredentials[utils.AwsSessionToken]; isPresent {
+		sparkAppParams["AwsSessionToken"] = "true"
+	}
+
 	job := utils.SparkJob{
 		Name:     "history-server-linear-regression",
-		Params:   awsParams,
+		Params:   sparkAppParams,
 		Template: "spark-linear-regression-history-server-job.yaml",
 	}
 
 	// Submit a SparkApplication
-	err = spark.SubmitJob(&job)
-	if err != nil {
+	if err := spark.SubmitJob(&job); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	err = spark.WaitUntilSucceeded(job)
-	if err != nil {
+	if err := spark.WaitUntilSucceeded(job); err != nil {
 		t.Error(err.Error())
 	}
 
 	// Find out History Server POD name
 	instanceName := fmt.Sprint(utils.OperatorName, "-history-server")
-	historyServerPodName, err := utils.Kubectl(
-		"get",
-		"pods",
+	historyServerPodName, err := utils.Kubectl("get", "pods",
 		fmt.Sprintf("--namespace=%s", spark.Namespace),
 		"--field-selector=status.phase=Running",
 		fmt.Sprintf("--selector=app.kubernetes.io/name=%s", instanceName),
@@ -203,7 +223,6 @@ func TestSparkHistoryServerInstallation(t *testing.T) {
 		log.Infof("Spark History Server logs:")
 		utils.Kubectl("logs", "-n", spark.Namespace, historyServerPodName)
 	}
-
 }
 
 func TestVolumeMounts(t *testing.T) {

--- a/tests/s3_test.go
+++ b/tests/s3_test.go
@@ -1,0 +1,117 @@
+package tests
+
+import (
+	"fmt"
+	. "github.com/google/uuid"
+	"github.com/mesosphere/kudo-spark-operator/tests/utils"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+const sparkApplicationName = "spark-s3-readwrite"
+const s3FileName = "README.md"
+
+type S3TestSuite struct {
+	operator utils.SparkOperatorInstallation
+	suite.Suite
+	awsCredentials map[string][]byte
+	s3BucketName   string
+	s3BucketPath   string
+}
+
+func TestS3Suite(t *testing.T) {
+	suite.Run(t, new(S3TestSuite))
+}
+
+func (suite *S3TestSuite) SetupSuite() {
+	installOperator(suite)
+	createAwsCredentialsSecret(suite)
+	if s3BucketName, err := utils.GetS3BucketName(); err != nil {
+		suite.FailNow("Failed to setup suite", err)
+	} else {
+		suite.s3BucketName = s3BucketName
+	}
+	if s3BucketPath, err := utils.GetS3BucketPath(); err != nil {
+		suite.FailNow("Failed to setup suite", err)
+	} else {
+		suite.s3BucketPath = s3BucketPath
+	}
+}
+
+func (suite *S3TestSuite) TearDownSuite() {
+	suite.operator.CleanUp()
+}
+
+func installOperator(suite *S3TestSuite) {
+	suite.operator = utils.SparkOperatorInstallation{}
+
+	if err := suite.operator.InstallSparkOperator(); err != nil {
+		suite.FailNow(err.Error())
+	}
+}
+
+func createAwsCredentialsSecret(suite *S3TestSuite) {
+	awsCredentials, err := utils.GetAwsCredentials()
+	if err != nil {
+		suite.FailNow(err.Error())
+	}
+	suite.awsCredentials = awsCredentials
+	if err := utils.CreateSecretEncoded(
+		suite.operator.K8sClients,
+		utils.DefaultAwsSecretName,
+		suite.operator.Namespace,
+		awsCredentials,
+	); err != nil {
+		suite.FailNow("Error while creating a Secret", err)
+	}
+}
+
+// test verifies read/write access to S3 bucket using EnvironmentVariableCredentialsProvider for authentication
+// by reading a file from S3 bucket, counting the lines and writing the result to another S3 location.
+// AWS environment variables are propagated to a driver and executors via a Secret object
+func (suite *S3TestSuite) TestS3ReadWriteAccess() {
+
+	testFolder := fmt.Sprint("s3a://", suite.s3BucketName, "/", suite.s3BucketPath, "/", sparkApplicationName)
+	fileFolder := fmt.Sprint(testFolder, "/", s3FileName)
+	uuid := New().String()
+	writeToFolder := fmt.Sprint(testFolder, "/", uuid)
+
+	params := map[string]interface{}{
+		// the name of a Secret with AWS credentials
+		"AwsSecretName": utils.DefaultAwsSecretName,
+		"ReadUrl":       fileFolder,
+		"WriteUrl":      writeToFolder,
+	}
+	if _, present := suite.awsCredentials[utils.AwsSessionToken]; present {
+		params["AwsSessionToken"] = "true"
+	}
+
+	sparkS3App := utils.SparkJob{
+		Name:     sparkApplicationName,
+		Template: fmt.Sprintf("%s.yaml", sparkApplicationName),
+		Params:   params,
+	}
+
+	if err := suite.operator.SubmitJob(&sparkS3App); err != nil {
+		suite.FailNow("Error submitting SparkApplication", err)
+	}
+
+	if err := suite.operator.WaitUntilSucceeded(sparkS3App); err != nil {
+		driverLog, _ := suite.operator.DriverLog(sparkS3App)
+		log.Info("Driver logs:\n", driverLog)
+		suite.FailNow(err.Error())
+	}
+
+	if driverLogContains, err := suite.operator.DriverLogContains(sparkS3App, "Wrote 105 lines"); err != nil {
+		log.Warn("Error while getting pod logs", err)
+	} else {
+		suite.True(driverLogContains)
+	}
+
+	// clean up S3 folder
+	if err := utils.AwsS3DeleteFolder(suite.s3BucketName, fmt.Sprint(testFolder, "/", uuid)); err != nil {
+		log.Warn(err)
+	}
+}

--- a/tests/security_test.go
+++ b/tests/security_test.go
@@ -333,7 +333,7 @@ func runSecretTest(secretName string, secretPath string, secretKey string, expec
 		secretData["secretKey"] = "secretValue"
 	}
 
-	err = utils.CreateSecret(spark.K8sClients, secretName, spark.Namespace, secretData)
+	err = utils.CreateSecretPlain(spark.K8sClients, secretName, spark.Namespace, secretData)
 	if err != nil {
 		return err
 	}

--- a/tests/templates/spark-linear-regression-history-server-job.yaml
+++ b/tests/templates/spark-linear-regression-history-server-job.yaml
@@ -61,3 +61,20 @@ spec:
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_SECRET_ACCESS_KEY
+      - name: AWS_SESSION_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_SESSION_TOKEN
+            optional: true

--- a/tests/templates/spark-linear-regression-history-server-job.yaml
+++ b/tests/templates/spark-linear-regression-history-server-job.yaml
@@ -61,20 +61,3 @@ spec:
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}
-    env:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_SECRET_ACCESS_KEY
-      - name: AWS_SESSION_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_SESSION_TOKEN
-            optional: true

--- a/tests/templates/spark-s3-readwrite.yaml
+++ b/tests/templates/spark-s3-readwrite.yaml
@@ -54,20 +54,3 @@ spec:
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}
-    env:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_SECRET_ACCESS_KEY
-      - name: AWS_SESSION_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: {{ .Params.AwsSecretName }}
-            key: AWS_SESSION_TOKEN
-            optional: true

--- a/tests/templates/spark-s3-readwrite.yaml
+++ b/tests/templates/spark-s3-readwrite.yaml
@@ -54,3 +54,20 @@ spec:
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}
+    env:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_SECRET_ACCESS_KEY
+      - name: AWS_SESSION_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Params.AwsSecretName }}
+            key: AWS_SESSION_TOKEN
+            optional: true

--- a/tests/templates/spark-s3-readwrite.yaml
+++ b/tests/templates/spark-s3-readwrite.yaml
@@ -8,28 +8,21 @@ spec:
   mode: cluster
   image: {{ .Image }}
   imagePullPolicy: Always
-  mainClass: org.apache.spark.examples.ml.LinearRegressionExample
-  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples_2.11-{{ .SparkVersion }}.jar"
-  arguments:
-    - "--regParam"
-    - "0.15"
-    - "--elasticNetParam"
-    - "1.0"
-    - "--maxIter"
-    - "1000000"
-    - "/opt/spark/data/mllib/sample_linear_regression_data.txt"
+  mainClass: S3Job
+  mainApplicationFile: "https://infinity-artifacts.s3.amazonaws.com/scale-tests/dcos-spark-scala-tests-assembly-2.4.0-20190325.jar"
   sparkConf:
     "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
     "spark.scheduler.minRegisteredResourcesRatio": "1.0"
-    "spark.eventLog.enabled": "true"
-    "spark.eventLog.dir": "{{ .Params.AwsBucketPath }}"
+    "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem"
     {{- if .Params.AwsSessionToken }}
     "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
     {{- end }}
-  deps:
-    jars:
-      - local:///opt/spark/examples/jars/scopt_2.11-3.7.0.jar
   sparkVersion: {{ .SparkVersion }}
+  arguments:
+    - "--readUrl"
+    - {{ .Params.ReadUrl }}
+    - "--writeUrl"
+    - {{ .Params.WriteUrl }}
   restartPolicy:
     type: Never
   driver:
@@ -57,7 +50,7 @@ spec:
             optional: true
   executor:
     cores: 1
-    instances: {{ .ExecutorsCount }}
+    instances: 1
     memory: "512m"
     labels:
       version: {{ .SparkVersion }}

--- a/tests/utils/aws_s3.go
+++ b/tests/utils/aws_s3.go
@@ -43,7 +43,7 @@ func GetAwsCredentials() (map[string][]byte, error) {
 	}
 
 	// support for Temporary Security Credentials
-	if awsSessionToken, isPresent := os.LookupEnv(AwsSessionToken); isPresent && len(awsSecretAccessKey) > 0 {
+	if awsSessionToken, isPresent := os.LookupEnv(AwsSessionToken); isPresent && len(awsSessionToken) > 0 {
 		awsEnvVars[AwsSessionToken] = []byte(awsSessionToken)
 	}
 	return awsEnvVars, nil

--- a/tests/utils/aws_s3.go
+++ b/tests/utils/aws_s3.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -10,6 +11,63 @@ import (
 
 	log "github.com/sirupsen/logrus"
 )
+
+const AwsAccessKeyId = "AWS_ACCESS_KEY_ID"
+const AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+const AwsSessionToken = "AWS_SESSION_TOKEN"
+const AwsBucketName = "AWS_BUCKET_NAME"
+const AwsBucketPath = "AWS_BUCKET_PATH"
+
+// this method looks up for the following AWS environment variables:
+//
+// - AWS_ACCESS_KEY_ID (required)
+// - AWS_SECRET_ACCESS_KEY (required)
+// - AWS_SESSION_TOKEN (optional)
+//
+// returns a map with env variable as a key with a value converted to a []byte.
+// the error is returned if one of the required variables is not set.
+func GetAwsCredentials() (map[string][]byte, error) {
+	awsAccessKeyId, err := checkEnvVar(AwsAccessKeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	awsSecretAccessKey, err := checkEnvVar(AwsSecretAccessKey)
+	if err != nil {
+		return nil, err
+	}
+
+	awsEnvVars := map[string][]byte{
+		AwsAccessKeyId:     []byte(awsAccessKeyId),
+		AwsSecretAccessKey: []byte(awsSecretAccessKey),
+	}
+
+	// support for Temporary Security Credentials
+	if awsSessionToken, isPresent := os.LookupEnv(AwsSessionToken); isPresent && len(awsSecretAccessKey) > 0 {
+		awsEnvVars[AwsSessionToken] = []byte(awsSessionToken)
+	}
+	return awsEnvVars, nil
+}
+
+// method returns the name of S3 bucket from AWS_BUCKET_NAME env variable
+func GetS3BucketName() (string, error) {
+	return checkEnvVar(AwsBucketName)
+}
+
+// method returns the S3 bucket path from AWS_BUCKET_PATH env variable
+func GetS3BucketPath() (string, error) {
+	return checkEnvVar(AwsBucketPath)
+}
+
+// method checks env variable and returns its value
+// returns error if variable is not set or empty
+func checkEnvVar(varName string) (string, error) {
+	value, isPresent := os.LookupEnv(varName)
+	if !isPresent || len(value) == 0 {
+		return "", fmt.Errorf("%s env variable is not set", varName)
+	}
+	return value, nil
+}
 
 // AwsS3CreateFolder will create a object in bucketName with folderPath as Key
 func AwsS3CreateFolder(bucketName string, folderPath string) error {

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -15,6 +15,7 @@ const DefaultNamespace = "kudo-spark-operator-testing"
 const OperatorName = "spark"
 const DefaultInstanceName = "test-instance"
 const DefaultServiceAccountSuffix = "-spark-service-account"
+const DefaultAwsSecretName = "aws-credentials"
 const rootDirName = "tests"
 const cmdLogFormat = ">%s %v\n%s"
 const DefaultRetryInterval = 5 * time.Second

--- a/tests/utils/k8s.go
+++ b/tests/utils/k8s.go
@@ -81,13 +81,28 @@ func CreateServiceAccount(clientSet *kubernetes.Clientset, name string, namespac
 	return err
 }
 
-func CreateSecret(clientSet *kubernetes.Clientset, name string, namespace string, secretData map[string]string) error {
-	log.Infof("Creating a secret %s/%s with Secret Data: %q", namespace, name, secretData)
+// Creates a secret with unencoded (plain) string data
+func CreateSecretPlain(clientSet *kubernetes.Clientset, name string, namespace string, secretData map[string]string) error {
+	log.Infof("Creating a secret %s/%s", namespace, name)
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		StringData: secretData,
+	}
+
+	_, err := clientSet.CoreV1().Secrets(namespace).Create(&secret)
+	return err
+}
+
+// Creates a secret used to store arbitrary data, encoded using base64
+func CreateSecretEncoded(clientSet *kubernetes.Clientset, name string, namespace string, secretData map[string][]byte) error {
+	log.Infof("Creating a secret %s/%s", namespace, name)
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: secretData,
 	}
 
 	_, err := clientSet.CoreV1().Secrets(namespace).Create(&secret)

--- a/tests/utils/spark_operator.go
+++ b/tests/utils/spark_operator.go
@@ -66,9 +66,10 @@ func (spark *SparkOperatorInstallation) InstallSparkOperator() error {
 		spark.Params = make(map[string]string)
 	}
 	if strings.Contains(OperatorImage, ":") {
-		operatorImage := strings.Split(OperatorImage, ":")
-		spark.Params["operatorImageName"] = operatorImage[0]
-		spark.Params["operatorVersion"] = operatorImage[1]
+		// handle the case, when using local docker registry (e.g. registry:5000/kudo-spark-operator:2.4.4-0.2.0)
+		tagIndex := strings.LastIndex(OperatorImage, ":")
+		spark.Params["operatorImageName"] = OperatorImage[0:tagIndex]
+		spark.Params["operatorVersion"] = OperatorImage[tagIndex+1:]
 	} else {
 		spark.Params["operatorImageName"] = OperatorImage
 	}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [D2IQ-63474: Integration test and docs for S3 access credentials](https://jira.d2iq.com/browse/D2IQ-63474).
This PR adds an integration test for verifying access to S3 from Spark job and Spark History Server using AWS credentials obtained from `Secrets`. Also, it modifies the existing test for Spark History server to adhere to the new method of handling credentials.

### Why are the changes needed?
- To check AWS credentials are propagated to Spark applications from a Secret
- To verify a new method of mounting Spark config file containing AWS credentials to the Spark History Server as a Secret, which name is passed via `historyServerSparkConfSecret` KUDO parameter.

PR for docs and updated configuration: https://github.com/kudobuilder/operators/pull/214 
Test job can be found here: https://github.com/mesosphere/spark-build/blob/master/tests/jobs/scala/src/main/scala/S3Job.scala

### How were the changes tested?
tests from this repo.