### PR TITLE
D2IQ-64032: Pin Volcano scheduler Docker image versions in tests

### DIFF
--- a/tests/resources/volcano/volcano-0.2.yaml
+++ b/tests/resources/volcano/volcano-0.2.yaml
@@ -124,7 +124,7 @@ spec:
       
       containers:
         - name: volcano-scheduler
-          image: volcanosh/vc-scheduler:latest
+          image: volcanosh/vc-scheduler:v0.2
           args:
             - --alsologtostderr
             - --scheduler-conf=/volcano.scheduler/volcano-scheduler.conf
@@ -223,7 +223,7 @@ spec:
             - --port=443
             - -v=4
             - 2>&1
-          image: volcanosh/vc-admission:latest
+          image: volcanosh/vc-admission:v0.2
           imagePullPolicy: IfNotPresent
           name: admission
           volumeMounts:
@@ -269,7 +269,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: main
-          image: volcanosh/vc-admission:latest
+          image: volcanosh/vc-admission:v0.2
           imagePullPolicy: IfNotPresent
           command: ["./gen-admission-secret.sh", "--service", "volcano-admission-service", "--namespace",
                     "volcano-system", "--secret", "volcano-admission-secret"]
@@ -361,7 +361,7 @@ spec:
       
       containers:
           - name: volcano-controllers
-            image: volcanosh/vc-controllers:latest
+            image: volcanosh/vc-controllers:v0.2
             args:
               - --alsologtostderr
               - -v=4

--- a/tests/volcano_test.go
+++ b/tests/volcano_test.go
@@ -5,9 +5,11 @@ import (
 	"github.com/mesosphere/kudo-spark-operator/tests/utils"
 	"github.com/stretchr/testify/suite"
 	"testing"
+	"time"
 )
 
 const volcanoInstallerPath = "resources/volcano/volcano-0.2.yaml"
+const volcanoDeploymentWaitTimeout = 5 * time.Minute
 
 type VolcanoIntegrationTestSuite struct {
 	operator utils.SparkOperatorInstallation
@@ -37,7 +39,7 @@ func (suite *VolcanoIntegrationTestSuite) SetupSuite() {
 		"--all",
 		"--for", "condition=available",
 		"--namespace", "volcano-system",
-		"--timeout=60s")
+		"--timeout", volcanoDeploymentWaitTimeout.String())
 }
 
 func (suite *VolcanoIntegrationTestSuite) TestAppRunOnVolcano() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [D2IQ-64032: Pin Volcano scheduler Docker image versions in tests](https://jira.d2iq.com/browse/D2IQ-64032).
This PR updates docker image versions for Volcano deployment in order to be consistent with the release version.

### Why are the changes needed?
We need to use version-specific tags for Volcano docker images instead of the `latest`, which are not stable and could cause compatibility issues between Volcano components.

### How were the changes tested?
tests from this repo.
