### PR TITLE
KUDO Spark Operator 2.4.5-1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Required software:
 * GNU Make 4.2.1 or higher
 * sha1sum
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.8.0 or higher
+* [KUDO CLI Plugin](https://kudo.dev/docs/#install-kudo-cli) 0.10.1 or higher
 
 For test cluster provisioning and Stub Universe artifacts upload valid AWS access credentials required:
 * `AWS_PROFILE` **or** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables should be provided
@@ -46,7 +46,7 @@ To run tests on a pre-existing cluster with specified operator and spark images,
 ```
 make test KUBECONFIG=$HOME/.kube/config \
 SPARK_IMAGE_FULL_NAME=mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s \
-OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:spark-2.4.5-hadoop-2.9-k8s
+OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:2.4.5-1.0.0
 ```
 
 # Installing and using Spark Operator

--- a/scripts/install_operator.sh
+++ b/scripts/install_operator.sh
@@ -6,7 +6,7 @@ OPERATOR_DIR="$(dirname ${SCRIPT_DIR})/operators/repository/spark/operator"
 
 NAMESPACE=${NAMESPACE:-spark}
 OPERATOR_DOCKER_REPO=${OPERATOR_DOCKER_REPO:-mesosphere/kudo-spark-operator}
-OPERATOR_VERSION=${OPERATOR_VERSION:-2.4.5-0.2.0}
+OPERATOR_VERSION=${OPERATOR_VERSION:-2.4.5-1.0.0}
 
 echo "Using namespace '${NAMESPACE}' for installation"
 

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -21,7 +21,7 @@ const cmdLogFormat = "> %s %v\n%s"
 const DefaultRetryInterval = 5 * time.Second
 const DefaultRetryTimeout = 10 * time.Minute
 
-var OperatorImage = GetenvOr("OPERATOR_IMAGE", "mesosphere/kudo-spark-operator:2.4.5-0.2.0")
+var OperatorImage = GetenvOr("OPERATOR_IMAGE", "mesosphere/kudo-spark-operator:2.4.5-1.0.0")
 var SparkImage = GetenvOr("SPARK_IMAGE", "mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s")
 var SparkVersion = GetenvOr("SPARK_VERSION", "2.4.5")
 var TestDir = GetenvOr("TEST_DIR", goUpToRootDir())

--- a/tests/utils/spark_operator.go
+++ b/tests/utils/spark_operator.go
@@ -66,7 +66,7 @@ func (spark *SparkOperatorInstallation) InstallSparkOperator() error {
 		spark.Params = make(map[string]string)
 	}
 	if strings.Contains(OperatorImage, ":") {
-		// handle the case, when using local docker registry (e.g. registry:5000/kudo-spark-operator:2.4.5-0.2.0)
+		// handle the case, when using local docker registry (e.g. registry:5000/kudo-spark-operator:2.4.5-1.0.0)
 		tagIndex := strings.LastIndex(OperatorImage, ":")
 		spark.Params["operatorImageName"] = OperatorImage[0:tagIndex]
 		spark.Params["operatorVersion"] = OperatorImage[tagIndex+1:]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [D2IQ-64395: Release KUDO Spark 1.0.0 to KUDO repository](https://jira.d2iq.com/browse/D2IQ-64395).

This PR contains updates related to the new release of Spark Operator.
The operator release PR:  https://github.com/kudobuilder/operators/pull/232

### Why are the changes needed?
To test the new release

### How were the changes tested?
test from this repo

Signed-off-by: Alex Lembiewski <alembiyeuski.c@d2iq.com>