### PR TITLE
Automate release process with Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+on:
+  push:
+    tags:
+      - 'v*' # triggered when a new tag is added, e.g. v2.4.5-1.0.1
+
+name: KUDO Spark Operator Release
+
+env:
+  SPARK_OPERATOR_DIR: operators/repository/spark/operator
+
+jobs:
+  build:
+    name: Package and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Configure git to use https instead of ssh
+        run: 'git config --global url."https://github.com/".insteadof git@github.com:'
+      - name: Update 'operators' submodule
+        run: git submodule update --init -- operators
+      - name: Extract release version from a tag ref
+        id: vars
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
+      - name: Extract KUDO version
+        run: echo "::set-env name=KUDO_VERSION::$(grep kudoVersion $SPARK_OPERATOR_DIR/operator.yaml | cut -d' ' -f2 | tr -d '"')"
+      - name: Download KUDO
+        run: |
+          curl -L https://github.com/kudobuilder/kudo/releases/download/v${{env.KUDO_VERSION}}/kudo_${{env.KUDO_VERSION}}_linux_x86_64.tar.gz | tar -xvz
+          chmod +x kubectl-kudo
+      - name: Package the operator
+        run: |
+          ./kubectl-kudo package create $SPARK_OPERATOR_DIR
+          echo "::set-env name=OPERATOR_PACKAGE_FILE::$(find spark-*.tgz)"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: KUDO Spark Operator ${{ steps.vars.outputs.version }}
+          draft: true
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.OPERATOR_PACKAGE_FILE }}
+          asset_name: ${{ env.OPERATOR_PACKAGE_FILE }}
+          asset_content_type: application/gzip

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ SPARK_IMAGE_FULL_NAME=mesosphere/spark:spark-2.4.5-hadoop-2.9-k8s \
 OPERATOR_IMAGE_FULL_NAME=mesosphere/kudo-spark-operator:2.4.5-1.0.1
 ```
 
+# Package and Release
+Release process is semi-automated and based on Github Actions. To make a new release:
+- Point the [operators](operators) submodule to the release commit, raise a PR and make sure the CI check is successful
+- After the PR is merged, create and push a new tag, e.g:
+```
+git tag -a v2.4.5-1.0.2 -m "KUDO Spark Operator 2.4.5-1.0.2 release"
+```   
+Pushing the new tag will trigger [release workflow](.github/workflows/release.yml), will build the operator package with KUDO,
+create a new GH release draft with the package attached to it.
+
+- Verify the new release (draft) is created and operator package attached as a release asset
+- Add the release notes and create publish the release
+ 
 # Installing and using Spark Operator
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Pushing the new tag will trigger [release workflow](.github/workflows/release.ym
 create a new GH release draft with the package attached to it.
 
 - Verify the new release (draft) is created and operator package attached as a release asset
-- Add the release notes and create publish the release
+- Add the release notes and publish the release
  
 # Installing and using Spark Operator
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds release automation workflow based on GitHub Actions. 

### Why are the changes needed?
- automate the release process
- to create an operator package automatically and attach it to the release

### How were the changes tested?
The workflow was developed and tested in a personal fork, results can be seen here:
- Run: https://github.com/alembiewski/kudo-spark-operator/runs/830062644
- Release example: https://github.com/alembiewski/kudo-spark-operator/releases
