### PR TITLE
Upgrading Konvoy to 1.5, upgrading fabric8 K8s client to 4.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SCRIPTS_DIR := $(ROOT_DIR)/scripts
 KUDO_TOOLS_DIR := $(ROOT_DIR)/shared
 SPARK_OPERATOR_DIR := $(ROOT_DIR)/spark-on-k8s-operator
 
-export KONVOY_VERSION ?= v1.3.0
+export KONVOY_VERSION ?= v1.5.0
 export WORKER_NODE_INSTANCE_TYPE ?= m5.xlarge
 export WORKER_NODE_COUNT ?= 5
 

--- a/images/spark/Dockerfile
+++ b/images/spark/Dockerfile
@@ -6,12 +6,14 @@ ARG SPARK_REPO="apache/spark"
 ARG SPARK_TAG="v2.4.5"
 ARG SCALA_VERSION="2.11"
 ARG HADOOP_VERSION="2.9.2"
+ARG KUBERNETES_CLIENT_VERSION="4.9.2"
 
 ARG SPARK_BUILD_ARGS="\
     -Pkubernetes \
     -Phadoop-cloud \
     -Pscala-${SCALA_VERSION} \
     -Dhadoop.version=${HADOOP_VERSION} \
+    -Dkubernetes.client.version=${KUBERNETES_CLIENT_VERSION} \
     -Pnetlib-lgpl \
     -Psparkr \
     -Phive \


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [D2IQ-71118: Update fabric8 client to support k8s 1.17](https://jira.d2iq.com/browse/D2IQ-71118).

### Why are the changes needed?
Java K8s client requires an upgrade for K8s 1.17. Relevant issues:
* https://github.com/apache/spark/pull/28601
* https://github.com/fabric8io/kubernetes-client/issues/2212

### How were the changes tested?
* integration tests from KUDO for Kubeflow repo
* integration tests from this repo