### PR TITLE
Updating Konvoy version to 1.6 GA, synchronize operator and image versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,16 @@ jobs:
         id: vars
         run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
       - name: Extract KUDO version
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         run: echo "::set-env name=KUDO_VERSION::$(grep kudoVersion $SPARK_OPERATOR_DIR/operator.yaml | cut -d' ' -f2 | tr -d '"')"
       - name: Download KUDO
         run: |
           curl -L https://github.com/kudobuilder/kudo/releases/download/v${{env.KUDO_VERSION}}/kudo_${{env.KUDO_VERSION}}_linux_x86_64.tar.gz | tar -xvz
           chmod +x kubectl-kudo
       - name: Package the operator
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         run: |
           ./kubectl-kudo package create $SPARK_OPERATOR_DIR
           echo "::set-env name=OPERATOR_PACKAGE_FILE::$(find spark-*.tgz)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SCRIPTS_DIR := $(ROOT_DIR)/scripts
 KUDO_TOOLS_DIR := $(ROOT_DIR)/shared
 SPARK_OPERATOR_DIR := $(ROOT_DIR)/spark-on-k8s-operator
 
-export KONVOY_VERSION ?= v1.6.0-rc.2
+export KONVOY_VERSION ?= v1.6.0
 export CLUSTER_CONFIG_YAML ?= $(ROOT_DIR)/cluster.template.yaml
 export WORKER_NODE_INSTANCE_TYPE ?= m5.2xlarge
 export WORKER_NODE_COUNT ?= 5

--- a/cluster.template.yaml
+++ b/cluster.template.yaml
@@ -10,7 +10,7 @@ spec:
     vpc:
       overrideDefaultRouteTable: true
       enableInternetGateway: true
-      enableVPCEndpoints: true
+      enableVPCEndpoints: false
     availabilityZones:
       - us-west-2c
     elb:
@@ -52,7 +52,7 @@ spec:
     user: centos
     publicKeyFile: kudo-spark-ssh.pub
     privateKeyFile: kudo-spark-ssh.pem
-  version: v1.6.0-rc.2
+  version: v1.6.0
 ---
 kind: ClusterConfiguration
 apiVersion: konvoy.mesosphere.io/v1beta2
@@ -61,17 +61,12 @@ metadata:
   creationTimestamp: "2020-01-28T23:15:38Z"
 spec:
   kubernetes:
-    version: 1.18.9
-    controlPlane:
-      controlPlaneEndpointOverride: ""
-      certificate: {}
+    version: 1.18.10
     networking:
       podSubnet: 192.168.0.0/16
       serviceSubnet: 10.0.0.0/18
       iptables:
         addDefaultRules: false
-      httpProxy: ""
-      httpsProxy: ""
     cloudProvider:
       provider: aws
     admissionPlugins:
@@ -80,20 +75,22 @@ spec:
         - NodeRestriction
   containerNetworking:
     calico:
-      version: v3.16.0
+      version: v3.16.4
       encapsulation: ipip
       mtu: 1480
   containerRuntime:
     containerd:
-      version: 1.3.4
+      version: 1.3.7
   osPackages:
     enableAdditionalRepositories: true
   nodePools:
     - name: worker
   addons:
     - configRepository: https://github.com/mesosphere/kubernetes-base-addons
-      configVersion: testing-2.5.0-3
+      configVersion: stable-1.18-3.0.0
       addonsList:
+        - name: ambassador # Ambassador is currently in Preview
+          enabled: false
         - name: awsebscsiprovisioner
           enabled: true
         - name: awsebsprovisioner
@@ -112,6 +109,8 @@ spec:
         - name: dex-k8s-authenticator
           enabled: true
         - name: elasticsearch
+          enabled: false
+        - name: elasticsearch-curator
           enabled: false
         - name: elasticsearchexporter
           enabled: false
@@ -166,19 +165,14 @@ spec:
                   secretKeyRef: null
         - name: velero
           enabled: false
-    - configRepository: https://github.com/mesosphere/kubeaddons-conductor
-      configVersion: stable-1.17-1.0.0
-      addonsList:
-        - name: conductor
-          enabled: false
     - configRepository: https://github.com/mesosphere/kubeaddons-dispatch
-      configVersion: stable-1.17-1.2.2
+      configVersion: stable-1.18-1.3.0
       addonsList:
       - name: dispatch
         enabled: false
     - configRepository: https://github.com/mesosphere/kubeaddons-kommander
-      configVersion: stable-1.17-1.1.0
+      configVersion: stable-1.18-1.2.0
       addonsList:
       - name: kommander
         enabled: false
-  version: v1.6.0-rc.2
+  version: v1.6.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades Konvoy from 1.6 RC2 to 1.6 GA and updates release versions in the operator definition and docs.

### Why are the changes needed?
To synchronize versions in image tags, operator parameters, and documentation.

### How were the changes tested?
* the PR build in TeamCity: https://teamcity.mesosphere.io/buildConfiguration/Frameworks_DataServices_Kudo_Spark_Pr_SparkPrKonvoyKudoV0100/3007417?buildTab=overview
