### PR TITLE
[bugfix] fixing metrics and Prometheus configs to export JVM metrics

### DIFF
--- a/images/spark/conf/metrics.properties
+++ b/images/spark/conf/metrics.properties
@@ -1,3 +1,2 @@
 *.sink.jmx.class=org.apache.spark.metrics.sink.JmxSink
-driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
-executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+*.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/images/spark/conf/prometheus.yaml
+++ b/images/spark/conf/prometheus.yaml
@@ -28,7 +28,7 @@ rules:
       executor_id: "$3"
   # These come from the application driver
   # Example: default/spark-pi.driver.DAGScheduler.stage.failedStages
-  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(\S+)><>Value
+  - pattern: metrics<name=(\S+)\.(\S+)\.driver\.(BlockManager|DAGScheduler|jvm)\.(.*)><>Value
     name: spark_driver_$3_$4
     type: GAUGE
     labels:

--- a/tests/test-s3/templates/spark-s3-readwrite.yaml
+++ b/tests/test-s3/templates/spark-s3-readwrite.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: mesosphere/spark-dev:e0f9eb2dcc71b2de6d3e0ce8a0f26c059430b946
+  image: mesosphere/spark-dev:57eeec111333edfefa2fb3179650537aae9b8a65
   imagePullPolicy: Always
   mainClass: S3Job
   mainApplicationFile: "https://kudo-spark.s3-us-west-2.amazonaws.com/spark-scala-tests-3.0.0-20200819.jar"

--- a/tests/test-spark-history-server/templates/mock-task-runner.yaml
+++ b/tests/test-spark-history-server/templates/mock-task-runner.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   type: Scala
   mode: cluster
-  image: mesosphere/spark-dev:e0f9eb2dcc71b2de6d3e0ce8a0f26c059430b946
+  image: mesosphere/spark-dev:57eeec111333edfefa2fb3179650537aae9b8a65
   imagePullPolicy: Always
   mainClass: MockTaskRunner
   mainApplicationFile: "https://kudo-spark.s3-us-west-2.amazonaws.com/spark-scala-tests-3.0.0-20200819.jar"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolves [D2IQ-73804: Fix Dashboards and Metrics](https://jira.d2iq.com/browse/D2IQ-73804).

### Why are the changes needed?
The root case was in the upgrade of the underlying Java metrics library in Spark (Dropwizard metrics) which lead to a mismatch of the new metrics paths with the Prometheus exporter patterns so the metrics were not exported.

### How were the changes tested?
Test application:
```
apiVersion: "sparkoperator.k8s.io/v1beta2"
kind: SparkApplication
metadata:
  name: mock-task-runner
spec:
  type: Scala
  mode: cluster
  image: mesosphere/spark-dev:e0a5c7f882d34cc9693134c48f8b38c60d4d986d
  imagePullPolicy: Always
  mainClass: MockTaskRunner
  mainApplicationFile: "https://kudo-spark.s3-us-west-2.amazonaws.com/spark-scala-tests-3.0.0-20200819.jar"
  arguments:
    - "1"
    - "6000"
  sparkConf:
    "spark.scheduler.maxRegisteredResourcesWaitingTime": "2400s"
    "spark.scheduler.minRegisteredResourcesRatio": "1.0"
    "spark.kubernetes.submission.connectionTimeout": "60000"
    "spark.kubernetes.submission.requestTimeout": "60000"
    "spark.local.dir": "/opt/spark/work-dir/tmp"
  sparkVersion: 3.0.0
  restartPolicy:
    type: Never
  driver:
    cores: 1
    memory: "512m"
    labels:
      version: 3.0.0
      metrics-exposed: "true"
    serviceAccount: spark-spark-service-account
    javaOptions: "-Djava.util.logging.config.file=/etc/metrics/conf/logging.properties"
  executor:
    cores: 1
    instances: 1
    memory: "512m"
    deleteOnTermination: false
    labels:
      version: 3.0.0
      metrics-exposed: "true"
  monitoring:
    exposeDriverMetrics: true
    exposeExecutorMetrics: true
    prometheus:
      jmxExporterJar: "/prometheus/jmx_prometheus_javaagent-0.11.0.jar"
      port: 8090
```
* by manually verifying the dashboards are picking up the metrics
   
   ![image](https://user-images.githubusercontent.com/1193506/105427266-9c2f4b80-5c01-11eb-91ce-331baf8d4eb5.png)
