### PR TITLE
[flake] explicitly specify HDFS resources in test to avoid OOM

### DIFF
--- a/tests/test-hdfs-kerberos-shs/hdfs-kerberos/datanode-deployment.yaml
+++ b/tests/test-hdfs-kerberos-shs/hdfs-kerberos/datanode-deployment.yaml
@@ -26,6 +26,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "1024Mi"
+            cpu: "1"
+          limits:
+            memory: "1024Mi"
+            cpu: "1"
         volumeMounts:
         - mountPath: /var/keytabs
           name: datanode-keytab

--- a/tests/test-hdfs-kerberos-shs/hdfs-kerberos/kerberos-deployment.yaml
+++ b/tests/test-hdfs-kerberos-shs/hdfs-kerberos/kerberos-deployment.yaml
@@ -26,6 +26,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "1"
+          limits:
+            memory: "512Mi"
+            cpu: "1"
         readinessProbe:
           exec:
             command:

--- a/tests/test-hdfs-kerberos-shs/hdfs-kerberos/namenode-deployment.yaml
+++ b/tests/test-hdfs-kerberos-shs/hdfs-kerberos/namenode-deployment.yaml
@@ -36,6 +36,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "1024Mi"
+            cpu: "1"
+          limits:
+            memory: "1024Mi"
+            cpu: "1"
       restartPolicy: Always
       volumes:
       - name: keytab


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR explicitly specifies resources for HDFS deployments in test to avoid potential issues with OOMKiller.

### How were the changes tested?
* running `test-hdfs-kerberos-shs` on a private cluster
* e2e tests from this repo